### PR TITLE
Improve CHANGELOG.md

### DIFF
--- a/doc/CHANGELOG.md
+++ b/doc/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## 0.8.0
 
-Editor 0.8.0 Released. It has ChromeApp version and DesktopApp version.
-DesktopApp version will abolished in the next major version (1.0.0).
+Editor 0.8.0 has been released. It contains ChromeApp version and DesktopApp version.
+DesktopApp version will be abolished in the next major version (1.0.0).
 Therefore, **ChromeApp version is recommended, DesktopApp version is deprecated**.
 
 ### ChromeApp
@@ -10,14 +10,14 @@ Therefore, **ChromeApp version is recommended, DesktopApp version is deprecated*
 * Split the button for exporting document into per filetype
 * Change official name from ThinReports to Thinreports #19
 * Improvement of combobox selection operation #37
-* Windowsのテーマをクラシックに設定するとテキストツールが正常に表示されない #11
-* Thinreport Editor auto close when right click #10
+* Windowsのテーマをクラシックに設定するとテキストツールが正常に表示されない #11 [Ayaka]
+* Thinreport Editor auto close when right click #10 [khacluan]
 * レイアウト定義書におけるページ番号ツールのカウント対象が一覧表の場合、表示されない
 * Does not resize the outline after updating content of the text in Property #42
 
 ### DesktopApp
 
-**[DEPRECATION] DesktopApp ver is deprecated.  Please use ChromeApp ver instead.**
+**[DEPRECATION] DesktopApp version is deprecated.  Please use ChromeApp version instead.**
 
 * Change official name from ThinReports to Thinreports #19
 * Improvement of combobox selection operation #37

--- a/doc/CHANGELOG.md
+++ b/doc/CHANGELOG.md
@@ -1,28 +1,28 @@
 ## 0.8.0
 
-Editor 0.8.0 has been released. It contains ChromeApp version and DesktopApp version.
-DesktopApp version will be abolished in the next major version (1.0.0).
-Therefore, **ChromeApp version is recommended, DesktopApp version is deprecated**.
+Editor 0.8.0 has been released. It includes two versions, ChromeApp ver and DesktopApp ver.
+However the DesktopApp ver has been deprecated and it will be **abolished** in the next major version.
 
-### ChromeApp
+### ChromeApp ver
 
 * New design for ChromeApp version #22
 * Split the button for exporting document into per filetype
 * Change official name from ThinReports to Thinreports #19
 * Improvement of combobox selection operation #37
-* Windowsのテーマをクラシックに設定するとテキストツールが正常に表示されない #11 [Ayaka]
-* Thinreport Editor auto close when right click #10 [khacluan]
-* レイアウト定義書におけるページ番号ツールのカウント対象が一覧表の場合、表示されない
-* Does not resize the outline after updating content of the text in Property #42
+* Fixed: Windowsのテーマをクラシックに設定するとテキストツールが正常に表示されない #11
+* Fixed: Thinreport Editor auto close when right click #10
+* Fixed: レイアウト定義書におけるページ番号ツールのカウント対象が一覧表の場合、表示されない
+* Fixed: Does not resize the outline after updating content of the text in Property #42
 
-### DesktopApp
+### DesktopApp ver
 
-**[DEPRECATION] DesktopApp version is deprecated.  Please use ChromeApp version instead.**
+**DEPRECATION:** This version won't be released in the next major version.
+Please use ChromeApp ver instead.
 
 * Change official name from ThinReports to Thinreports #19
 * Improvement of combobox selection operation #37
-* レイアウト定義書におけるページ番号ツールのカウント対象が一覧表の場合、表示されない
-* Does not resize the outline after updating content of the text in Property #42
+* Fixed: レイアウト定義書におけるページ番号ツールのカウント対象が一覧表の場合、表示されない
+* Fixed: Does not resize the outline after updating content of the text in Property #42
 
 ## 0.7.7.2
 


### PR DESCRIPTION
CHANGELOGを直してみました。見てもらえると幸いです。

変更点としては
* 「0.8.0のエディタをリリースした」
  * https://www.ruby-lang.org/en/news/2015/04/13/ruby-2-1-6-released/ を参考にしました。
* 「0.8.0のエディタはChromeApp版とDesktopApp版を含んでいる」
  * 0.8.0のエディタというものにChromeApp版とDesktopApp版が包括されていることを表現するために include ではなく contains にしました。
* 報告してくれた人のアカウント名を追加しました。
  * 表記は https://github.com/amatsuda/kaminari/blob/master/CHANGELOG.rdoc を参考にしました。