### PR TITLE
New format for layout file

### DIFF
--- a/src/app/boot.js
+++ b/src/app/boot.js
@@ -572,7 +572,7 @@ thin.init_ = function() {
             }
           }
 
-          try {
+          // try {
             var workspace = thin.core.Workspace.create(file);
             if (workspace) {
               var targetVersion = workspace.getLayout().getFormat().getVersion();
@@ -590,42 +590,42 @@ thin.init_ = function() {
                 }
               };
 
-              switch(thin.layout.checkCompatibility(targetVersion)) {
-                case compatibilityState.WARNING:
-                  thin.ui.Message.confirm(thin.t('text_layout_force_edit_confirmation'),
-                      thin.t('label_confirmation'),
-                      function(e) {
-                        if (e.isOk()) {
-                          addPageHandler();
-                        }
-                      });
-                  break;
-                case compatibilityState.ERROR:
-                  throw new thin.Error(thin.t('error_can_not_edit_layout_file',
-                      {'required': thin.layout.inspectCompatibleRule(),
-                       'version': targetVersion}));
-                  break;
-                default:
+              // switch(thin.layout.checkCompatibility(targetVersion)) {
+              //   case compatibilityState.WARNING:
+              //     thin.ui.Message.confirm(thin.t('text_layout_force_edit_confirmation'),
+              //         thin.t('label_confirmation'),
+              //         function(e) {
+              //           if (e.isOk()) {
+              //             addPageHandler();
+              //           }
+              //         });
+              //     break;
+              //   case compatibilityState.ERROR:
+              //     throw new thin.Error(thin.t('error_can_not_edit_layout_file',
+              //         {'required': thin.layout.inspectCompatibleRule(),
+              //          'version': targetVersion}));
+              //     break;
+              //   default:
                   addPageHandler();
-                  break;
-              }
+              //     break;
+              // }
             }
-          } catch (er) {
-            var message;
-            if (er instanceof thin.Error) {
-              message = er.message;
-            } else {
-              message = thin.t('error_unknown');
-            }
+          // } catch (er) {
+            // var message;
+            // if (er instanceof thin.Error) {
+            //   message = er.message;
+            // } else {
+            //   message = thin.t('error_unknown');
+            // }
 
-            thin.ui.Message.alert(message, 'Error',
-              function(er) {
-                var activeWorkspace = thin.core.getActiveWorkspace();
-                if (activeWorkspace) {
-                  activeWorkspace.focusElement(er);
-                }
-              });
-          }
+            // thin.ui.Message.alert(message, 'Error',
+            //   function(er) {
+            //     var activeWorkspace = thin.core.getActiveWorkspace();
+            //     if (activeWorkspace) {
+            //       activeWorkspace.focusElement(er);
+            //     }
+            //   });
+          // }
         },
         cancel: goog.nullFunction,
         error: function(code) {

--- a/src/app/boot.js
+++ b/src/app/boot.js
@@ -490,10 +490,11 @@ thin.init_ = function() {
       pageHeightInput.setEnabled(false);
       pageHeightInput.setValue('');
 
-      pageMarginTop.setValue(thin.layout.FormatPage.DEFAULT_SETTINGS['margin-top']);
-      pageMarginBottom.setValue(thin.layout.FormatPage.DEFAULT_SETTINGS['margin-bottom']);
-      pageMarginLeft.setValue(thin.layout.FormatPage.DEFAULT_SETTINGS['margin-left']);
-      pageMarginRight.setValue(thin.layout.FormatPage.DEFAULT_SETTINGS['margin-right']);
+      var defaultMargin = thin.layout.FormatPage.DEFAULT_SETTINGS['margin'];
+      pageMarginTop.setValue(defaultMargin[0]);
+      pageMarginBottom.setValue(defaultMargin[1]);
+      pageMarginLeft.setValue(defaultMargin[2]);
+      pageMarginRight.setValue(defaultMargin[3]);
 
       dialog.setVisible(true);
     });
@@ -572,7 +573,7 @@ thin.init_ = function() {
             }
           }
 
-          // try {
+          try {
             var workspace = thin.core.Workspace.create(file);
             if (workspace) {
               var targetVersion = workspace.getLayout().getFormat().getVersion();
@@ -590,42 +591,42 @@ thin.init_ = function() {
                 }
               };
 
-              // switch(thin.layout.checkCompatibility(targetVersion)) {
-              //   case compatibilityState.WARNING:
-              //     thin.ui.Message.confirm(thin.t('text_layout_force_edit_confirmation'),
-              //         thin.t('label_confirmation'),
-              //         function(e) {
-              //           if (e.isOk()) {
-              //             addPageHandler();
-              //           }
-              //         });
-              //     break;
-              //   case compatibilityState.ERROR:
-              //     throw new thin.Error(thin.t('error_can_not_edit_layout_file',
-              //         {'required': thin.layout.inspectCompatibleRule(),
-              //          'version': targetVersion}));
-              //     break;
-              //   default:
+              switch(thin.layout.checkCompatibility(targetVersion)) {
+                case compatibilityState.WARNING:
+                  thin.ui.Message.confirm(thin.t('text_layout_force_edit_confirmation'),
+                      thin.t('label_confirmation'),
+                      function(e) {
+                        if (e.isOk()) {
+                          addPageHandler();
+                        }
+                      });
+                  break;
+                case compatibilityState.ERROR:
+                  throw new thin.Error(thin.t('error_can_not_edit_layout_file',
+                      {'required': thin.layout.inspectCompatibleRule(),
+                       'version': targetVersion}));
+                  break;
+                default:
                   addPageHandler();
-              //     break;
-              // }
+                  break;
+              }
             }
-          // } catch (er) {
-            // var message;
-            // if (er instanceof thin.Error) {
-            //   message = er.message;
-            // } else {
-            //   message = thin.t('error_unknown');
-            // }
+          } catch (er) {
+            var message;
+            if (er instanceof thin.Error) {
+              message = er.message;
+            } else {
+              message = thin.t('error_unknown');
+            }
 
-            // thin.ui.Message.alert(message, 'Error',
-            //   function(er) {
-            //     var activeWorkspace = thin.core.getActiveWorkspace();
-            //     if (activeWorkspace) {
-            //       activeWorkspace.focusElement(er);
-            //     }
-            //   });
-          // }
+            thin.ui.Message.alert(message, 'Error',
+              function(er) {
+                var activeWorkspace = thin.core.getActiveWorkspace();
+                if (activeWorkspace) {
+                  activeWorkspace.focusElement(er);
+                }
+              });
+          }
         },
         cancel: goog.nullFunction,
         error: function(code) {

--- a/src/app/boot.js
+++ b/src/app/boot.js
@@ -442,15 +442,19 @@ thin.init_ = function() {
 
       dialog.addEventListener(goog.ui.Dialog.EventType.SELECT, function(e) {
         if (e.isOk()) {
+          var margin = [];
+          goog.array.insertAt(margin, pageMarginTop.getValue() || 0, 0);
+          goog.array.insertAt(margin, pageMarginRight.getValue() || 0, 1);
+          goog.array.insertAt(margin, pageMarginBottom.getValue() || 0, 2);
+          goog.array.insertAt(margin, pageMarginLeft.getValue() || 0, 3);
+
           var paperTypeValue = paperTypeSelectbox.getValue();
-          var formatConfig = {
+          var report = {
             'paper-type': paperTypeValue,
             'orientation': pageDirectionSelectbox.getValue(),
-            'margin-top': pageMarginTop.getValue() || 0,
-            'margin-bottom': pageMarginBottom.getValue() || 0,
-            'margin-left': pageMarginLeft.getValue() || 0,
-            'margin-right': pageMarginRight.getValue() || 0
+            'margin': margin
           };
+
           if (thin.layout.FormatPage.isUserType(paperTypeValue)) {
             var userWidth = pageWidthInput.getValue();
             var userHeight = pageHeightInput.getValue();
@@ -462,14 +466,13 @@ thin.init_ = function() {
               });
               return false;
             }
-            formatConfig['width'] = Number(userWidth);
-            formatConfig['height'] = Number(userHeight);
+            report['width'] = Number(userWidth);
+            report['height'] = Number(userHeight);
           }
           var format = new thin.layout.Format();
-          format.page = format.setPage({
-            'title': pageTitleInput.getValue(),
-            'page': formatConfig
-          });
+          format.page = format.setPage(report);
+          format.page.setTitle(pageTitleInput.getValue());
+
           var workspace = new thin.core.Workspace(format);
           tabpane.addPage(new thin.ui.TabPane.TabPage(workspace.getTabName(), workspace));
           workspace.setup();
@@ -492,9 +495,9 @@ thin.init_ = function() {
 
       var defaultMargin = thin.layout.FormatPage.DEFAULT_SETTINGS['margin'];
       pageMarginTop.setValue(defaultMargin[0]);
-      pageMarginBottom.setValue(defaultMargin[1]);
-      pageMarginLeft.setValue(defaultMargin[2]);
-      pageMarginRight.setValue(defaultMargin[3]);
+      pageMarginRight.setValue(defaultMargin[1]);
+      pageMarginBottom.setValue(defaultMargin[2]);
+      pageMarginLeft.setValue(defaultMargin[3]);
 
       dialog.setVisible(true);
     });

--- a/src/app/core/abstracttextgroup.js
+++ b/src/app/core/abstracttextgroup.js
@@ -143,15 +143,27 @@ thin.core.AbstractTextGroup.prototype.setTextLineHeightRatio = function(ratio) {
 
 
 /**
+ * @deprecated See: https://github.com/thinreports/thinreports-editor/issues/38
+ * @param {string|number} spacing
+ * @return {string}
+ */
+thin.core.AbstractTextGroup.prototype.convertKerningToDefaultInSince06 = function(spacing) {
+  if (isNaN(Number(spacing))) {
+    spacing = thin.core.TextStyle.DEFAULT_KERNING;
+  }
+
+  return spacing;
+};
+
+
+/**
  * @param {string} spacing
  */
 thin.core.AbstractTextGroup.prototype.setKerning = function(spacing) {
   var layout = this.getLayout();
   var element = this.getElement();
 
-  if (isNaN(Number(spacing))) {
-    spacing = thin.core.TextStyle.DEFAULT_KERNING;
-  }
+  spacing = this.convertKerningToDefaultInSince06(spacing);
 
   if (thin.isExactlyEqual(spacing, thin.core.TextStyle.DEFAULT_KERNING)) {
     layout.setElementAttributes(element, {
@@ -382,38 +394,38 @@ thin.core.AbstractTextGroup.prototype.disposeInternal = function() {
 /**
  * @return {string}
  */
-thin.core.AbstractTextGroup.prototype.getTextAnchorToHash = function() {
-  var textAlignToHash = '';
+thin.core.AbstractTextGroup.prototype.getTextAnchorAsJSON = function() {
+  var textAlignAsJSON = '';
   var horizonAlignType = thin.core.TextStyle.HorizonAlignType;
 
   // SVG: start, middle, end
   // TLF: left, center, right
   switch(this.getTextAnchor()) {
     case horizonAlignType.MIDDLE:
-      textAlignToHash = 'center';
+      textAlignAsJSON = 'center';
       break;
     case horizonAlignType.END:
-      textAlignToHash = 'right';
+      textAlignAsJSON = 'right';
       break;
     default:
-      textAlignToHash = 'left';
+      textAlignAsJSON = 'left';
       break;
   }
 
-  return textAlignToHash;
+  return textAlignAsJSON;
 };
 
 
 /**
- * @param {string} textAlignToHash
+ * @param {string} textAlignFromJSON
  */
-thin.core.AbstractTextGroup.prototype.setTextAnchorFromHash = function(textAlignToHash) {
+thin.core.AbstractTextGroup.prototype.setTextAnchorFromJSON = function(textAlignFromJSON) {
   var anchor = '';
   var horizonAlignType = thin.core.TextStyle.HorizonAlignType;
 
   // SVG: start, middle, end
   // TLF: left, center, right
-  switch(textAlignToHash) {
+  switch(textAlignFromJSON) {
     case 'center':
       anchor = horizonAlignType.MIDDLE;
       break;
@@ -432,43 +444,43 @@ thin.core.AbstractTextGroup.prototype.setTextAnchorFromHash = function(textAlign
 /**
  * @return {string}
  */
-thin.core.AbstractTextGroup.prototype.getVerticalAlignToHash = function() {
-  var verticalAlignToHash = '';
+thin.core.AbstractTextGroup.prototype.getVerticalAlignAsJSON = function() {
+  var verticalAlignAsJSON = '';
   var verticalAlignType = thin.core.TextStyle.VerticalAlignType;
 
   // SVG: top, center, bottom
   // TLF: top, middle, bottom
   switch(this.getVerticalAlign()) {
     case verticalAlignType.CENTER:
-      verticalAlignToHash = 'middle';
+      verticalAlignAsJSON = 'middle';
       break;
     case verticalAlignType.BOTTOM:
-      verticalAlignToHash = verticalAlignType.BOTTOM;
+      verticalAlignAsJSON = verticalAlignType.BOTTOM;
       break;
     default:
-      verticalAlignToHash = verticalAlignType.TOP;
+      verticalAlignAsJSON = verticalAlignType.TOP;
       break;
   }
 
-  return verticalAlignToHash;
+  return verticalAlignAsJSON;
 };
 
 
 /**
- * @param {string} verticalAlignToHash
+ * @param {string} verticalAlignFromJSON
  */
-thin.core.AbstractTextGroup.prototype.setVerticalAlignFromHash = function(verticalAlignToHash) {
+thin.core.AbstractTextGroup.prototype.setVerticalAlignFromJSON = function(verticalAlignFromJSON) {
   var valign = '';
   var verticalAlignType = thin.core.TextStyle.VerticalAlignType;
 
   // SVG: top, center, bottom
   // TLF: top, middle, bottom
-  switch(verticalAlignToHash) {
+  switch(verticalAlignFromJSON) {
     case 'middle':
       valign = verticalAlignType.CENTER;
       break;
     default:
-      valign = verticalAlignToHash;
+      valign = verticalAlignFromJSON;
       break;
   }
 
@@ -479,8 +491,8 @@ thin.core.AbstractTextGroup.prototype.setVerticalAlignFromHash = function(vertic
 /**
  * @return {Object}
  */
-thin.core.AbstractTextGroup.prototype.toHash = function() {
-  var hash = this.toHash_();
+thin.core.AbstractTextGroup.prototype.asJSON = function() {
+  var object = this.asJSON_();
 
   var lineHeight = this.getTextLineHeight();
   var lineHeightRatio = this.getTextLineHeightRatio();
@@ -494,21 +506,21 @@ thin.core.AbstractTextGroup.prototype.toHash = function() {
     letterSpecing = Number(letterSpecing);
   }
 
-  goog.object.extend(hash['style'], {
+  goog.object.extend(object['style'], {
     'font-family': [ this.getFontFamily() ],
     'font-size': this.getFontSize(),
-    'color': goog.object.get(hash['style'], 'fill-color'),
-    'text-align': this.getTextAnchorToHash(),
-    'vertical-align': this.getVerticalAlignToHash(),
+    'color': goog.object.get(object['style'], 'fill-color'),
+    'text-align': this.getTextAnchorAsJSON(),
+    'vertical-align': this.getVerticalAlignAsJSON(),
     'line-height': lineHeight,
     'line-height-ratio': lineHeightRatio,
     'letter-spacing': letterSpecing
   });
-  goog.object.extend(hash['style'], this.fontStyle_.toHash());
+  goog.object.extend(object['style'], this.fontStyle_.asJSON());
 
-  goog.object.remove(hash['style'], 'fill-color');
+  goog.object.remove(object['style'], 'fill-color');
 
-  return hash;
+  return object;
 };
 
 
@@ -530,10 +542,10 @@ thin.core.AbstractTextGroup.prototype.update = function(attrs) {
         this.setFillColor(value);
         break;
       case 'text-align':
-        this.setTextAnchorFromHash(value);
+        this.setTextAnchorFromJSON(value);
         break;
       case 'vertical-align':
-        this.setVerticalAlignFromHash(value);
+        this.setVerticalAlignFromJSON(value);
         break;
       case 'line-height-ratio':
         this.setTextLineHeightRatio(value);

--- a/src/app/core/abstracttextgroup.js
+++ b/src/app/core/abstracttextgroup.js
@@ -477,16 +477,27 @@ thin.core.AbstractTextGroup.prototype.setVerticalAlignFromHash = function(vertic
 thin.core.AbstractTextGroup.prototype.toHash = function() {
   var hash = this.toHash_();
 
+  var lineHeight = this.getTextLineHeight();
+  var lineHeightRatio = this.getTextLineHeightRatio();
+  if (!thin.isExactlyEqual(lineHeightRatio, thin.core.TextStyle.DEFAULT_LINEHEIGHT)) {
+    lineHeight = Number(lineHeight);
+    lineHeightRatio = Number(lineHeightRatio);
+  }
+
+  var letterSpecing = this.getKerning();
+  if (!thin.isExactlyEqual(letterSpecing, thin.core.TextStyle.DEFAULT_KERNING)) {
+    letterSpecing = Number(letterSpecing);
+  }
+
   goog.object.extend(hash['style'], {
-    'font-family': this.getFontFamily(),
+    'font-family': [ this.getFontFamily() ],
     'font-size': this.getFontSize(),
     'color': goog.object.get(hash['style'], 'fill-color'),
     'text-align': this.getTextAnchorToHash(),
     'vertical-align': this.getVerticalAlignToHash(),
-    // default is blank
-    'line-height': this.getTextLineHeight(),
-    'line-height-ratio': this.getTextLineHeightRatio(),
-    'letter-spacing': this.getKerning()
+    'line-height': lineHeight,
+    'line-height-ratio': lineHeightRatio,
+    'letter-spacing': letterSpecing
   });
   goog.object.extend(hash['style'], this.fontStyle_.toHash());
 
@@ -505,7 +516,7 @@ thin.core.AbstractTextGroup.prototype.update = function(attrs) {
   goog.object.forEach(attrs, function(value, attr) {
     switch (attr) {
       case 'font-family':
-        this.setFontFamily(value);
+        this.setFontFamily(value[0]);
         break;
       case 'font-size':
         this.setFontSize(value);

--- a/src/app/core/abstracttextgroup.js
+++ b/src/app/core/abstracttextgroup.js
@@ -148,6 +148,11 @@ thin.core.AbstractTextGroup.prototype.setTextLineHeightRatio = function(ratio) {
 thin.core.AbstractTextGroup.prototype.setKerning = function(spacing) {
   var layout = this.getLayout();
   var element = this.getElement();
+
+  if (isNaN(Number(spacing))) {
+    spacing = thin.core.TextStyle.DEFAULT_KERNING;
+  }
+
   if (thin.isExactlyEqual(spacing, thin.core.TextStyle.DEFAULT_KERNING)) {
     layout.setElementAttributes(element, {
       'kerning': thin.core.TextStyle.DEFAULT_ELEMENT_KERNING,

--- a/src/app/core/action.js
+++ b/src/app/core/action.js
@@ -1338,7 +1338,6 @@ thin.core.Action.prototype.actionDeleteShapes = function(historyMode) {
   var targetIndexByShapes = layout.getTargetIndexOfShapes(targetShapes, parentGroup);
   var captureShapeIdArray = [];
   var captureRefIdArray = [];
-  var captureReferenceShapesArray = [];
   var captureReferringShapesArray = [];
   var defaultRefId = thin.core.TblockShape.DEFAULT_REFID;
 
@@ -1347,11 +1346,9 @@ thin.core.Action.prototype.actionDeleteShapes = function(historyMode) {
 
     if (shape.instanceOfTblockShape()) {
       goog.array.insertAt(captureRefIdArray, shape.getRefId(), count);
-      goog.array.insertAt(captureReferenceShapesArray, shape.getReferenceShape(), count);
       goog.array.insertAt(captureReferringShapesArray, shape.getReferringShapes(), count);
     } else {
       goog.array.insertAt(captureRefIdArray, defaultRefId, count);
-      goog.array.insertAt(captureReferenceShapesArray, null, count);
       goog.array.insertAt(captureReferringShapesArray, null, count);
     }
 
@@ -1399,7 +1396,7 @@ thin.core.Action.prototype.actionDeleteShapes = function(historyMode) {
           if (shape.instanceOfTblockShape()) {
             var captureRefId = captureRefIdArray[count];
             if (!thin.isExactlyEqual(captureRefId, defaultRefId)) {
-              shape.setRefId(captureRefId, captureReferenceShapesArray[count]);
+              shape.setRefId(captureRefId);
             }
           }
 
@@ -1413,10 +1410,9 @@ thin.core.Action.prototype.actionDeleteShapes = function(historyMode) {
         goog.array.forEach(captureReferringShapesArray, function(referringShapes, count) {
           if (goog.isArray(referringShapes) && !goog.array.isEmpty(referringShapes)) {
             var refId = captureShapeIdArray[count];
-            var referencesShape = shapes[count];
             goog.array.forEach(referringShapes, function(shape) {
               if (!shape.isReferring()) {
-                shape.setRefId(refId, referencesShape);
+                shape.setRefId(refId);
               }
             });
           }
@@ -1477,7 +1473,7 @@ thin.core.Action.prototype.actionDeleteShapes = function(historyMode) {
             if (shape.instanceOfTblockShape()) {
               var captureRefId = captureRefIdArray[count];
               if (!thin.isExactlyEqual(captureRefId, defaultRefId)) {
-                shape.setRefId(captureRefId, captureReferenceShapesArray[count]);
+                shape.setRefId(captureRefId);
               }
             }
 
@@ -1491,10 +1487,9 @@ thin.core.Action.prototype.actionDeleteShapes = function(historyMode) {
           goog.array.forEach(captureReferringShapesArray, function(referringShapes, count) {
             if (goog.isArray(referringShapes) && !goog.array.isEmpty(referringShapes)) {
               var refId = captureShapeIdArray[count];
-              var referencesShape = shapes[count];
               goog.array.forEach(referringShapes, function(shape) {
                 if (!shape.isReferring()) {
-                  shape.setRefId(refId, referencesShape);
+                  shape.setRefId(refId);
                 }
               });
             }

--- a/src/app/core/component.js
+++ b/src/app/core/component.js
@@ -44,6 +44,67 @@ goog.mixin(thin.core.Component.prototype, thin.core.ModuleElement.prototype);
 thin.core.Component.prototype.setup = goog.nullFunction;
 
 
+/**
+ * The latest fill applied to this element.
+ * @type {goog.graphics.Fill?}
+ * @protected
+ */
+thin.core.Component.prototype.fill = null;
+
+
+/**
+ * The latest stroke applied to this element.
+ * @type {goog.graphics.Stroke?}
+ * @private
+ */
+thin.core.Component.prototype.stroke_ = null;
+
+
+/**
+ * Sets the fill for this element.
+ * @param {goog.graphics.Fill?} fill The fill object.
+ */
+thin.core.Component.prototype.setFill = function(fill) {
+  this.fill = fill;
+  this.setFillInternal();
+};
+
+
+/**
+ * @return {goog.graphics.Fill?} fill The fill object.
+ */
+thin.core.Component.prototype.getFill = function() {
+  return this.fill;
+};
+
+
+/**
+ * Sets the stroke for this element.
+ * @param {goog.graphics.Stroke?} stroke The stroke object.
+ */
+thin.core.Component.prototype.setStroke = function(stroke) {
+  this.stroke_ = stroke;
+  this.setStrokeInternal();
+};
+
+
+/**
+ * @return {goog.graphics.Stroke?} stroke The stroke object.
+ */
+thin.core.Component.prototype.getStroke = function() {
+  return this.stroke_;
+};
+
+
+thin.core.Component.prototype.setFillInternal = goog.abstractMethod;
+
+
+thin.core.Component.prototype.setStrokeInternal = goog.abstractMethod;
+
+
+thin.core.Component.prototype.getStrokeWidth = goog.abstractMethod;
+
+
 /** @inheritDoc */
 thin.core.Component.prototype.disposeInternal = function() {
   thin.core.Component.superClass_.disposeInternal.call(this);

--- a/src/app/core/ellipse.js
+++ b/src/app/core/ellipse.js
@@ -35,13 +35,13 @@ thin.core.Ellipse = function(element, layout, stroke, fill) {
   var cy = Number(layout.getElementAttribute(element, 'cy'));
   var rx = Number(layout.getElementAttribute(element, 'rx'));
   var ry = Number(layout.getElementAttribute(element, 'ry'));
-  
+
   /**
    * @type {number}
    * @private
    */
   this.left_ = thin.numberWithPrecision(cx - rx);
-  
+
   /**
    * @type {number}
    * @private
@@ -59,7 +59,7 @@ thin.core.Ellipse = function(element, layout, stroke, fill) {
    * @private
    */
   this.height_ = thin.numberWithPrecision(ry * 2);
-  
+
   /**
    * @type {number}
    * @private
@@ -94,8 +94,18 @@ goog.mixin(thin.core.Ellipse.prototype, thin.core.ModuleElement.prototype);
 thin.core.Ellipse.prototype.setLeft = function(left) {
   left = thin.numberWithPrecision(left - this.getParentTransLateX());
   this.left_ = left;
-  var cx = thin.numberWithPrecision(left + this.rx_, 2);
+
+  this.setCx(left + this.rx_);
+};
+
+
+/**
+ * @param {number} cx
+ */
+thin.core.Ellipse.prototype.setCx = function(cx) {
+  cx = thin.numberWithPrecision(cx, 2);
   this.cx_ = cx;
+
   this.getLayout().setElementAttributes(this.getElement(), {
     'cx': cx
   });
@@ -108,8 +118,18 @@ thin.core.Ellipse.prototype.setLeft = function(left) {
 thin.core.Ellipse.prototype.setTop = function(top) {
   top = thin.numberWithPrecision(top - this.getParentTransLateY());
   this.top_ = top;
-  var cy = thin.numberWithPrecision(top + this.ry_, 2);
+
+  this.setCy(top + this.ry_);
+};
+
+
+/**
+ * @param {number} cy
+ */
+thin.core.Ellipse.prototype.setCy = function(cy) {
+  cy = thin.numberWithPrecision(cy, 2);
   this.cy_ = cy;
+
   this.getLayout().setElementAttributes(this.getElement(), {
     'cy': cy
   });
@@ -122,8 +142,18 @@ thin.core.Ellipse.prototype.setTop = function(top) {
 thin.core.Ellipse.prototype.setWidth = function(width) {
   width = thin.numberWithPrecision(width);
   this.width_ = width;
-  var rx = thin.numberWithPrecision(width / 2, 2);
+
+  this.setRx(width / 2);
+};
+
+
+/**
+ * @param {number} rx
+ */
+thin.core.Ellipse.prototype.setRx = function(rx) {
+  rx = thin.numberWithPrecision(rx, 2)
   this.rx_ = rx;
+
   this.getLayout().setElementAttributes(this.getElement(), {
     'rx': rx
   });
@@ -136,7 +166,16 @@ thin.core.Ellipse.prototype.setWidth = function(width) {
 thin.core.Ellipse.prototype.setHeight = function(height) {
   height = thin.numberWithPrecision(height);
   this.height_ = height;
-  var ry = thin.numberWithPrecision(height / 2, 2);
+
+  this.setRy(height / 2);
+};
+
+
+/**
+ * @param {number} ry
+ */
+thin.core.Ellipse.prototype.setRy = function(ry) {
+  ry = thin.numberWithPrecision(ry, 2);
   this.ry_ = ry;
   this.getLayout().setElementAttributes(this.getElement(), {
     'ry': ry
@@ -144,11 +183,45 @@ thin.core.Ellipse.prototype.setHeight = function(height) {
 };
 
 
+thin.core.Ellipse.prototype.resetTop = function() {
+  if ((goog.isNumber(this.ry_) && this.ry_ != 0) &&
+    (goog.isNumber(this.cy_) && this.cy_ != 0)) {
+
+    this.top_ = thin.numberWithPrecision(this.cy_ - this.ry_);
+  }
+};
+
+
+thin.core.Ellipse.prototype.resetLeft = function() {
+  if ((goog.isNumber(this.rx_) && this.rx_ != 0) &&
+    (goog.isNumber(this.cx_) && this.cx_ != 0)) {
+
+    this.left_ = thin.numberWithPrecision(this.cx_ - this.rx_);
+  }
+};
+
+
+thin.core.Ellipse.prototype.resetWidth = function() {
+  if (goog.isNumber(this.rx_) && this.rx_ != 0) {
+
+    this.width_ = thin.numberWithPrecision(this.rx_ * 2);
+  }
+};
+
+
+thin.core.Ellipse.prototype.resetHeight = function() {
+  if (goog.isNumber(this.ry_) && this.ry_ != 0) {
+
+    this.height_ = thin.numberWithPrecision(this.ry_ * 2);
+  }
+};
+
+
 /**
  * @return {goog.math.Coordinate}
  */
 thin.core.Ellipse.prototype.getCenterCoordinate = function() {
-  return new goog.math.Coordinate(this.cx_ + this.getParentTransLateX(), 
+  return new goog.math.Coordinate(this.cx_ + this.getParentTransLateX(),
                                   this.cy_ + this.getParentTransLateY());
 };
 
@@ -167,8 +240,11 @@ thin.core.Ellipse.prototype.getRadius = function() {
  * @param {number} cy Center Y coordinate.
  */
 thin.core.Ellipse.prototype.setCenter = function(cx, cy) {
-  this.setLeft(cx - this.rx_);
-  this.setTop(cy - this.ry_);
+  this.setCx(cx);
+  this.setCy(cy);
+
+  this.resetLeft();
+  this.resetTop();
 };
 
 
@@ -178,8 +254,9 @@ thin.core.Ellipse.prototype.setCenter = function(cx, cy) {
  * @param {number} ry Radius length for the y-axis.
  */
 thin.core.Ellipse.prototype.setRadius = function(rx, ry) {
-  this.setWidth(rx * 2);
-  this.setHeight(ry * 2);
-  this.setLeft(this.getLeft());
-  this.setTop(this.getTop());
+  this.setRx(rx);
+  this.setRy(ry);
+
+  this.resetWidth();
+  this.resetHeight();
 };

--- a/src/app/core/ellipseshape.js
+++ b/src/app/core/ellipseshape.js
@@ -335,23 +335,22 @@ thin.core.EllipseShape.prototype.disposeInternal = function() {
 /**
  * @return {Object}
  */
-thin.core.EllipseShape.prototype.toHash = function() {
-  var hash = this.toHash_();
+thin.core.EllipseShape.prototype.asJSON = function() {
+  var object = this.asJSON_();
 
-  // var radius = this.getRadius();
-  goog.object.extend(hash, {
+  goog.object.extend(object, {
     'cx': this.cx_,
     'cy': this.cy_,
     'rx': this.rx_,
     'ry': this.ry_
   });
 
-  goog.object.remove(hash, 'x');
-  goog.object.remove(hash, 'y');
-  goog.object.remove(hash, 'width');
-  goog.object.remove(hash, 'height');
+  goog.object.remove(object, 'x');
+  goog.object.remove(object, 'y');
+  goog.object.remove(object, 'width');
+  goog.object.remove(object, 'height');
 
-  return hash;
+  return object;
 };
 
 

--- a/src/app/core/ellipseshape.js
+++ b/src/app/core/ellipseshape.js
@@ -63,27 +63,6 @@ thin.core.EllipseShape.prototype.getClassId = function() {
 };
 
 
-/**
- * @param {Element} element
- * @param {thin.core.Layout} layout
- * @param {thin.core.ShapeIdManager=} opt_shapeIdManager
- * @return {thin.core.EllipseShape}
- */
-thin.core.EllipseShape.createFromElement = function(element, layout, opt_shapeIdManager) {
-  var shape = new thin.core.EllipseShape(element, layout, 
-                new goog.graphics.Stroke(
-                      Number(layout.getElementAttribute(element, 'stroke-width')),
-                      layout.getElementAttribute(element, 'stroke')),
-                new goog.graphics.SolidFill(layout.getElementAttribute(element, 'fill')));
-  shape.setShapeId(layout.getElementAttribute(element, 'x-id'), opt_shapeIdManager);
-  shape.setDisplay(layout.getElementAttribute(element, 'x-display') == 'true');
-  shape.setDesc(layout.getElementAttribute(element, 'x-desc'));
-  shape.setStrokeDashFromType(layout.getElementAttribute(element, 'x-stroke-type'));
-  shape.initIdentifier();
-  return shape;
-};
-
-
 thin.core.EllipseShape.prototype.setDefaultOutline = function() {
   this.setTargetOutline(this.getLayout().getHelpers().getEllipseOutline());
 };
@@ -114,7 +93,7 @@ thin.core.EllipseShape.prototype.getCloneCreator = function() {
   var fill = this.getFill();
   var display = this.getDisplay();
   var isAffiliationListShape = this.isAffiliationListShape();
-  
+
   /**
    * @param {thin.core.Layout} layout
    * @param {boolean=} opt_isAdaptDeltaForList
@@ -148,17 +127,17 @@ thin.core.EllipseShape.prototype.createPropertyComponent_ = function() {
   var scope = this;
   var propEventType = thin.ui.PropertyPane.Property.EventType;
   var proppane = thin.ui.getComponent('proppane');
-  
+
   var baseGroup = proppane.addGroup(thin.t('property_group_basis'));
-  
-  
+
+
   var leftInputProperty = new thin.ui.PropertyPane.NumberInputProperty(thin.t('field_left_position'));
   var leftInput = leftInputProperty.getValueControl();
   leftInput.getNumberValidator().setAllowDecimal(true, 1);
-  
+
   leftInputProperty.addEventListener(propEventType.CHANGE,
       this.setLeftForPropertyUpdate, false, this);
-  
+
   proppane.addProperty(leftInputProperty, baseGroup, 'left');
 
 
@@ -168,56 +147,56 @@ thin.core.EllipseShape.prototype.createPropertyComponent_ = function() {
 
   topInputProperty.addEventListener(propEventType.CHANGE,
       this.setTopForPropertyUpdate, false, this);
-  
+
   proppane.addProperty(topInputProperty, baseGroup, 'top');
-  
-  
+
+
   var widthInputProperty = new thin.ui.PropertyPane.NumberInputProperty(thin.t('field_width'));
   var widthInput = widthInputProperty.getValueControl();
   widthInput.getNumberValidator().setAllowDecimal(true, 1);
-  
+
   widthInputProperty.addEventListener(propEventType.CHANGE,
       this.setWidthForPropertyUpdate, false, this);
-  
+
   proppane.addProperty(widthInputProperty, baseGroup, 'width');
-  
-  
+
+
   var heightInputProperty = new thin.ui.PropertyPane.NumberInputProperty(thin.t('field_height'));
   var heightInput = heightInputProperty.getValueControl();
   heightInput.getNumberValidator().setAllowDecimal(true, 1);
-  
+
   heightInputProperty.addEventListener(propEventType.CHANGE,
       this.setHeightForPropertyUpdate, false, this);
-  
+
   proppane.addProperty(heightInputProperty, baseGroup, 'height');
-  
-  
+
+
   var displayCheckProperty = new thin.ui.PropertyPane.CheckboxProperty(thin.t('field_display'));
   displayCheckProperty.addEventListener(propEventType.CHANGE,
       this.setDisplayForPropertyUpdate, false, this);
-  
+
   proppane.addProperty(displayCheckProperty, baseGroup, 'display');
 
-  
+
   var shapeGroup = proppane.addGroup(thin.t('property_group_shape'));
-  
-  
+
+
   var fillInputProperty = new thin.ui.PropertyPane.ColorProperty(thin.t('field_fill_color'));
   fillInputProperty.getValueControl().getInput().setLabel('none');
   fillInputProperty.addEventListener(propEventType.CHANGE,
       this.setFillForPropertyUpdate, false, this);
-  
+
   proppane.addProperty(fillInputProperty , shapeGroup, 'fill');
-  
-  
+
+
   var strokeInputProperty = new thin.ui.PropertyPane.ColorProperty(thin.t('field_stroke_color'));
   strokeInputProperty.getValueControl().getInput().setLabel('none');
   strokeInputProperty.addEventListener(propEventType.CHANGE,
       this.setStrokeForPropertyUpdate, false, this);
-  
+
   proppane.addProperty(strokeInputProperty , shapeGroup, 'stroke');
-  
-  
+
+
   var strokeWidthCombProperty = new thin.ui.PropertyPane.ComboBoxProperty(thin.t('field_stroke_width'));
   var strokeWidthComb = strokeWidthCombProperty.getValueControl();
   var strokeWidthInput = strokeWidthComb.getInput();
@@ -236,7 +215,7 @@ thin.core.EllipseShape.prototype.createPropertyComponent_ = function() {
   });
   strokeWidthCombProperty.addEventListener(propEventType.CHANGE,
       this.setStrokeWidthForPropertyUpdate, false, this);
-  
+
   proppane.addProperty(strokeWidthCombProperty , shapeGroup, 'stroke-width');
 
   var strokeType = thin.core.ModuleElement.StrokeType;
@@ -251,25 +230,25 @@ thin.core.EllipseShape.prototype.createPropertyComponent_ = function() {
       new thin.ui.Option(thin.core.ModuleElement.getStrokeName(strokeType.DASHED), strokeType.DASHED));
   strokeDashSelect.addItem(
       new thin.ui.Option(thin.core.ModuleElement.getStrokeName(strokeType.DOTTED), strokeType.DOTTED));
-  
+
   strokeDashSelectProperty.addEventListener(propEventType.CHANGE,
       this.setStrokeDashTypeForPropertyUpdate, false, this);
-  
+
   proppane.addProperty(strokeDashSelectProperty , shapeGroup, 'stroke-dash-type');
 
 
   var cooperationGroup = proppane.addGroup(thin.t('property_group_association'));
-  
+
   var idInputProperty = new thin.ui.PropertyPane.IdInputProperty(this, 'ID');
   idInputProperty.addEventListener(propEventType.CHANGE,
       this.setShapeIdForPropertyUpdate, false, this);
-  
+
   proppane.addProperty(idInputProperty, cooperationGroup, 'shape-id');
-  
+
   var descProperty = new thin.ui.PropertyPane.InputProperty(thin.t('field_description'));
   descProperty.addEventListener(propEventType.CHANGE,
       this.setDescPropertyUpdate, false, this);
-  
+
   proppane.addProperty(descProperty, cooperationGroup, 'desc');
 };
 
@@ -306,7 +285,7 @@ thin.core.EllipseShape.prototype.updateProperties = function() {
   var properties = this.getProperties();
   var proppaneBlank = thin.core.ModuleShape.PROPPANE_SHOW_BLANK;
   var noneColor = thin.core.ModuleShape.NONE;
-  
+
   proppane.getPropertyControl('left').setValue(properties['left']);
   proppane.getPropertyControl('top').setValue(properties['top']);
   proppane.getPropertyControl('width').setValue(properties['width']);
@@ -327,7 +306,7 @@ thin.core.EllipseShape.prototype.updateProperties = function() {
     strokeWidth = proppaneBlank;
   }
   proppane.getPropertyControl('stroke-width').setInternalValue(strokeWidth);
-  
+
   proppane.getPropertyControl('stroke-dash-type').setValue(properties['stroke-dash-type']);
   proppane.getPropertyControl('shape-id').setValue(properties['shape-id']);
   proppane.getPropertyControl('desc').setValue(properties['desc']);
@@ -350,4 +329,64 @@ thin.core.EllipseShape.prototype.setInitShapeProperties = function(properties) {
 thin.core.EllipseShape.prototype.disposeInternal = function() {
   thin.core.EllipseShape.superClass_.disposeInternal.call(this);
   this.disposeInternalForShape();
+};
+
+
+/**
+ * @return {Object}
+ */
+thin.core.EllipseShape.prototype.toHash = function() {
+  var hash = this.toHash_();
+
+  // var radius = this.getRadius();
+  goog.object.extend(hash, {
+    'cx': this.cx_,
+    'cy': this.cy_,
+    'rx': this.rx_,
+    'ry': this.ry_
+  });
+
+  goog.object.remove(hash, 'x');
+  goog.object.remove(hash, 'y');
+  goog.object.remove(hash, 'width');
+  goog.object.remove(hash, 'height');
+
+  return hash;
+};
+
+
+/**
+ * @param {Object} attrs
+ */
+thin.core.EllipseShape.prototype.update = function(attrs) {
+  goog.object.forEach(attrs, function(value, attr) {
+    switch (attr) {
+      case 'rx':
+        this.setRx(value);
+        this.resetLeft();
+        this.resetWidth();
+
+        break;
+      case 'ry':
+        this.setRy(value);
+        this.resetTop();
+        this.resetHeight();
+
+        break;
+      case 'cx':
+        this.setCx(value);
+        this.resetLeft();
+
+        break;
+      case 'cy':
+        this.setCy(value);
+        this.resetTop();
+
+        break;
+      default:
+        break;
+      }
+  }, this);
+
+  this.update_(attrs);
 };

--- a/src/app/core/fontstyle.js
+++ b/src/app/core/fontstyle.js
@@ -76,7 +76,7 @@ thin.core.FontStyle.prototype.decoration;
 /**
  * @return {Object}
  */
-thin.core.FontStyle.prototype.toHash = function() {
+thin.core.FontStyle.prototype.asJSON = function() {
   var array = [];
 
   if (this.bold) {

--- a/src/app/core/fontstyle.js
+++ b/src/app/core/fontstyle.js
@@ -71,3 +71,28 @@ thin.core.FontStyle.prototype.linethrough = false;
  * @type {string}
  */
 thin.core.FontStyle.prototype.decoration;
+
+
+/**
+ * @return {Object}
+ */
+thin.core.FontStyle.prototype.toHash = function() {
+  var array = [];
+
+  if (this.bold) {
+    array.push('bold');
+  }
+  if (this.italic) {
+    array.push('italic');
+  }
+  if (this.linethrough) {
+    array.push('linethrough');
+  }
+  if (this.underline) {
+    array.push('underline');
+  }
+
+  return {
+    'font-style': array
+  };
+};

--- a/src/app/core/formatstyle/abstractformat.js
+++ b/src/app/core/formatstyle/abstractformat.js
@@ -27,4 +27,8 @@ thin.core.formatstyles.AbstractFormat = function() {
 };
 goog.inherits(thin.core.formatstyles.AbstractFormat, goog.Disposable);
 
+
 thin.core.formatstyles.AbstractFormat.prototype.inspect = goog.abstractMethod;
+
+
+thin.core.formatstyles.AbstractFormat.prototype.toHash = goog.abstractMethod;

--- a/src/app/core/formatstyle/abstractformat.js
+++ b/src/app/core/formatstyle/abstractformat.js
@@ -31,4 +31,4 @@ goog.inherits(thin.core.formatstyles.AbstractFormat, goog.Disposable);
 thin.core.formatstyles.AbstractFormat.prototype.inspect = goog.abstractMethod;
 
 
-thin.core.formatstyles.AbstractFormat.prototype.toHash = goog.abstractMethod;
+thin.core.formatstyles.AbstractFormat.prototype.asJSON = goog.abstractMethod;

--- a/src/app/core/formatstyle/datetimeformat.js
+++ b/src/app/core/formatstyle/datetimeformat.js
@@ -68,3 +68,15 @@ thin.core.formatstyles.DatetimeFormat.prototype.disposeInternal = function() {
   
   delete this.format_;
 };
+
+
+/**
+ * @return {Object}
+ */
+thin.core.formatstyles.DatetimeFormat.prototype.toHash = function() {
+  return {
+    'datetime': {
+      'format': this.getFormat()
+    }
+  };
+};

--- a/src/app/core/formatstyle/datetimeformat.js
+++ b/src/app/core/formatstyle/datetimeformat.js
@@ -25,7 +25,7 @@ goog.require('thin.core.formatstyles.AbstractFormat');
  */
 thin.core.formatstyles.DatetimeFormat = function(datetimeFormat) {
   thin.core.formatstyles.AbstractFormat.call(this);
-  
+
   /**
    * @type {string}
    * @private
@@ -65,7 +65,7 @@ thin.core.formatstyles.DatetimeFormat.prototype.inspect = function() {
 /** @inheritDoc */
 thin.core.formatstyles.DatetimeFormat.prototype.disposeInternal = function() {
   goog.base(this, 'disposeInternal');
-  
+
   delete this.format_;
 };
 
@@ -73,7 +73,7 @@ thin.core.formatstyles.DatetimeFormat.prototype.disposeInternal = function() {
 /**
  * @return {Object}
  */
-thin.core.formatstyles.DatetimeFormat.prototype.toHash = function() {
+thin.core.formatstyles.DatetimeFormat.prototype.asJSON = function() {
   return {
     'datetime': {
       'format': this.getFormat()

--- a/src/app/core/formatstyle/numberformat.js
+++ b/src/app/core/formatstyle/numberformat.js
@@ -126,3 +126,16 @@ thin.core.formatstyles.NumberFormat.prototype.disposeInternal = function() {
   delete this.delimiter_;
   delete this.precision_;
 };
+
+
+/**
+ * @return {Object}
+ */
+thin.core.formatstyles.NumberFormat.prototype.toHash = function() {
+  return {
+    'number': {
+      'delimiter': this.getDelimiter(),
+      'precision': this.getPrecision()
+    }
+  };
+};

--- a/src/app/core/formatstyle/numberformat.js
+++ b/src/app/core/formatstyle/numberformat.js
@@ -27,9 +27,9 @@ goog.require('thin.core.formatstyles.AbstractFormat');
  */
 thin.core.formatstyles.NumberFormat = function(delimiter, precision, enabled) {
   thin.core.formatstyles.AbstractFormat.call(this);
-  
+
   var disableDelimiter = thin.core.formatstyles.NumberFormat.DISABLE_DELIMITER;
-  
+
   if (enabled) {
     if (thin.isExactlyEqual(delimiter, disableDelimiter)) {
       delimiter = thin.core.formatstyles.NumberFormat.DEFAULT_DELIMITER;
@@ -43,14 +43,14 @@ thin.core.formatstyles.NumberFormat = function(delimiter, precision, enabled) {
    * @private
    */
   this.delimiter_ = delimiter;
-  
+
   /**
    * @type {number}
    * @private
    */
   this.precision_ = precision;
-  
-  
+
+
   /**
    * @type {boolean}
    * @private
@@ -122,7 +122,7 @@ thin.core.formatstyles.NumberFormat.prototype.inspect = function() {
 /** @inheritDoc */
 thin.core.formatstyles.NumberFormat.prototype.disposeInternal = function() {
   goog.base(this, 'disposeInternal');
-  
+
   delete this.delimiter_;
   delete this.precision_;
 };
@@ -131,7 +131,7 @@ thin.core.formatstyles.NumberFormat.prototype.disposeInternal = function() {
 /**
  * @return {Object}
  */
-thin.core.formatstyles.NumberFormat.prototype.toHash = function() {
+thin.core.formatstyles.NumberFormat.prototype.asJSON = function() {
   return {
     'number': {
       'delimiter': this.getDelimiter(),

--- a/src/app/core/formatstyle/paddingformat.js
+++ b/src/app/core/formatstyle/paddingformat.js
@@ -141,3 +141,17 @@ thin.core.formatstyles.PaddingFormat.prototype.disposeInternal = function() {
   delete this.len_;
   delete this.char_;
 };
+
+
+/**
+ * @return {Object}
+ */
+thin.core.formatstyles.PaddingFormat.prototype.toHash = function() {
+  return {
+    'padding': {
+      'length': this.getLength(),
+      'char': this.getChar(),
+      'direction': this.getDirection()
+    }
+  };
+};

--- a/src/app/core/formatstyle/paddingformat.js
+++ b/src/app/core/formatstyle/paddingformat.js
@@ -146,7 +146,7 @@ thin.core.formatstyles.PaddingFormat.prototype.disposeInternal = function() {
 /**
  * @return {Object}
  */
-thin.core.formatstyles.PaddingFormat.prototype.toHash = function() {
+thin.core.formatstyles.PaddingFormat.prototype.asJSON = function() {
   return {
     'padding': {
       'length': this.getLength(),

--- a/src/app/core/imageblockshape.js
+++ b/src/app/core/imageblockshape.js
@@ -673,7 +673,7 @@ thin.core.ImageblockShape.prototype.disposeInternal = function() {
 /**
  * @return {string}
  */
-thin.core.ImageblockShape.prototype.getPositionXToHash = function() {
+thin.core.ImageblockShape.prototype.getPositionXAsJSON = function() {
   return this.getPositionX();
 };
 
@@ -681,51 +681,51 @@ thin.core.ImageblockShape.prototype.getPositionXToHash = function() {
 /**
  * @return {string}
  */
-thin.core.ImageblockShape.prototype.getPositionYToHash = function() {
-  var postionYToHash = '';
+thin.core.ImageblockShape.prototype.getPositionYAsJSON = function() {
+  var postionYAsJSON = '';
   var postionYType = thin.core.ImageblockShape.PositionY;
 
   // SVG: top, center, bottom
   // TLF: top, middle, bottom
   switch(this.getPositionY()) {
     case postionYType.CENTER:
-      postionYToHash = 'middle';
+      postionYAsJSON = 'middle';
       break;
     case postionYType.BOTTOM:
-      postionYToHash = postionYType.BOTTOM;
+      postionYAsJSON = postionYType.BOTTOM;
       break;
     default:
-      postionYToHash = postionYType.TOP;
+      postionYAsJSON = postionYType.TOP;
       break;
   }
 
-  return postionYToHash;
+  return postionYAsJSON;
 };
 
 
 /**
- * @param {string|thin.core.ImageblockShape.PositionX} position
+ * @param {string|thin.core.ImageblockShape.PositionX} positionXFromJSON
  */
-thin.core.ImageblockShape.prototype.setPositionXFromHash = function(position) {
-  this.setPositionX(position);
+thin.core.ImageblockShape.prototype.setPositionXFromJSON = function(positionXFromJSON) {
+  this.setPositionX(positionXFromJSON);
 };
 
 
 /**
- * @param {string|thin.core.ImageblockShape.PositionY} postionYToHash
+ * @param {string|thin.core.ImageblockShape.PositionY} postionYFromJSON
  */
-thin.core.ImageblockShape.prototype.setPositionYFromHash = function(postionYToHash) {
+thin.core.ImageblockShape.prototype.setPositionYFromJSON = function(postionYFromJSON) {
   var position = '';
   var postionYType = thin.core.ImageblockShape.PositionY;
 
   // SVG: top, center, bottom
   // TLF: top, middle, bottom
-  switch(postionYToHash) {
+  switch(postionYFromJSON) {
     case 'middle':
       position = postionYType.CENTER;
       break;
     default:
-      position = postionYToHash;
+      position = postionYFromJSON;
       break;
   }
 
@@ -744,15 +744,15 @@ thin.core.ImageblockShape.prototype.getType = function() {
 /**
  * @return {Object}
  */
-thin.core.ImageblockShape.prototype.toHash = function() {
-  var hash = this.toHash_();
+thin.core.ImageblockShape.prototype.asJSON = function() {
+  var object = this.asJSON_();
 
-  goog.object.extend(hash['style'], {
-    'position-x': this.getPositionXToHash(),
-    'position-y': this.getPositionYToHash()
+  goog.object.extend(object['style'], {
+    'position-x': this.getPositionXAsJSON(),
+    'position-y': this.getPositionYAsJSON()
   });
 
-  return hash;
+  return object;
 };
 
 
@@ -765,10 +765,10 @@ thin.core.ImageblockShape.prototype.update = function(attrs) {
   goog.object.forEach(attrs, function(value, attr) {
     switch (attr) {
       case 'position-x':
-        this.setPositionXFromHash(value);
+        this.setPositionXFromJSON(value);
         break;
       case 'position-y':
-        this.setPositionYFromHash(value);
+        this.setPositionYFromJSON(value);
         break;
       default:
         break;

--- a/src/app/core/imageblockshape.js
+++ b/src/app/core/imageblockshape.js
@@ -238,26 +238,6 @@ thin.core.ImageblockShape.prototype.getStrokeWidth = function() {
 
 
 /**
- * @param {Element} element
- * @param {thin.core.Layout} layout
- * @param {thin.core.ShapeIdManager=} opt_shapeIdManager
- * @return {thin.core.ImageblockShape}
- */
-thin.core.ImageblockShape.createFromElement = function(element, layout, opt_shapeIdManager) {
-  var shape = new thin.core.ImageblockShape(element, layout);
-
-  shape.setShapeId(layout.getElementAttribute(element, 'x-id'), opt_shapeIdManager);
-  shape.setDisplay(layout.getElementAttribute(element, 'x-display') == 'true');
-  shape.setDesc(layout.getElementAttribute(element, 'x-desc'));
-  shape.setPositionX(layout.getElementAttribute(element, 'x-position-x'));
-  shape.setPositionY(layout.getElementAttribute(element, 'x-position-y'));
-  shape.initIdentifier();
-
-  return shape;
-};
-
-
-/**
  * @param {Element=} opt_element
  * @return {thin.core.Box}
  * @private
@@ -687,4 +667,111 @@ thin.core.ImageblockShape.prototype.disposeInternal = function() {
 
   delete this.positionX_;
   delete this.positionY_;
+};
+
+
+/**
+ * @return {string}
+ */
+thin.core.ImageblockShape.prototype.getPositionXToHash = function() {
+  return this.getPositionX();
+};
+
+
+/**
+ * @return {string}
+ */
+thin.core.ImageblockShape.prototype.getPositionYToHash = function() {
+  var postionYToHash = '';
+  var postionYType = thin.core.ImageblockShape.PositionY;
+
+  // SVG: top, center, bottom
+  // TLF: top, middle, bottom
+  switch(this.getPositionY()) {
+    case postionYType.CENTER:
+      postionYToHash = 'middle';
+      break;
+    case postionYType.BOTTOM:
+      postionYToHash = postionYType.BOTTOM;
+      break;
+    default:
+      postionYToHash = postionYType.TOP;
+      break;
+  }
+
+  return postionYToHash;
+};
+
+
+/**
+ * @param {string|thin.core.ImageblockShape.PositionX} position
+ */
+thin.core.ImageblockShape.prototype.setPositionXFromHash = function(position) {
+  this.setPositionX(position);
+};
+
+
+/**
+ * @param {string|thin.core.ImageblockShape.PositionY} postionYToHash
+ */
+thin.core.ImageblockShape.prototype.setPositionYFromHash = function(postionYToHash) {
+  var position = '';
+  var postionYType = thin.core.ImageblockShape.PositionY;
+
+  // SVG: top, center, bottom
+  // TLF: top, middle, bottom
+  switch(postionYToHash) {
+    case 'middle':
+      position = postionYType.CENTER;
+      break;
+    default:
+      position = postionYToHash;
+      break;
+  }
+
+  this.setPositionY(position);
+};
+
+
+/**
+ * @return {string}
+ */
+thin.core.ImageblockShape.prototype.getType = function() {
+  return 'image-block';
+};
+
+
+/**
+ * @return {Object}
+ */
+thin.core.ImageblockShape.prototype.toHash = function() {
+  var hash = this.toHash_();
+
+  goog.object.extend(hash['style'], {
+    'position-x': this.getPositionXToHash(),
+    'position-y': this.getPositionYToHash()
+  });
+
+  return hash;
+};
+
+
+/**
+ * @param {Object} attrs
+ */
+thin.core.ImageblockShape.prototype.update = function(attrs) {
+  this.update_(attrs);
+
+  goog.object.forEach(attrs, function(value, attr) {
+    switch (attr) {
+      case 'position-x':
+        this.setPositionXFromHash(value);
+        break;
+      case 'position-y':
+        this.setPositionYFromHash(value);
+        break;
+      default:
+        break;
+      }
+  }, this);
 };

--- a/src/app/core/imagefile.js
+++ b/src/app/core/imagefile.js
@@ -132,18 +132,6 @@ thin.core.ImageFile.handleSelectFileToOpen = function(callbacks, entry) {
 
 
 /**
- * @param {Element} element
- * @return {thin.core.ImageFile}
- */
-thin.core.ImageFile.createFromElement = function(element) {
-  var entry = thin.File.createDummyEntry('DummyImageFile');
-  var coreFile = new thin.File(entry, '', element.href.baseVal);
-
-  return new thin.core.ImageFile(coreFile);
-};
-
-
-/**
  * @return {string}
  */
 thin.core.ImageFile.prototype.getPath = function() {

--- a/src/app/core/imageshape.js
+++ b/src/app/core/imageshape.js
@@ -82,24 +82,6 @@ thin.core.ImageShape.prototype.getClassId = function() {
 
 
 /**
- * @param {Element} element
- * @param {thin.core.Layout} layout
- * @param {thin.core.ShapeIdManager=} opt_shapeIdManager
- * @return {thin.core.ImageShape}
- */
-thin.core.ImageShape.createFromElement = function(element, layout, opt_shapeIdManager) {
-  var shape = new thin.core.ImageShape(element, layout);
-  shape.setShapeId(layout.getElementAttribute(element, 'x-id'), opt_shapeIdManager);
-  shape.setDisplay(layout.getElementAttribute(element, 'x-display') == 'true');
-  shape.setDesc(layout.getElementAttribute(element, 'x-desc'));
-  shape.setFile(thin.core.ImageFile.createFromElement(element));
-  shape.initIdentifier();
-
-  return shape;
-};
-
-
-/**
  * @param {number} width
  * @param {number} height
  */
@@ -454,4 +436,72 @@ thin.core.ImageShape.prototype.getFile = function() {
 thin.core.ImageShape.prototype.disposeInternal = function() {
   goog.base(this, 'disposeInternal');
   this.disposeInternalForShape();
+};
+
+
+/**
+ * @return {null}
+ */
+thin.core.ImageShape.prototype.getStroke = function() {
+  return null;
+};
+
+
+/**
+ * @return {null}
+ */
+thin.core.ImageShape.prototype.getFill = function() {
+  return null;
+};
+
+
+/**
+ * @return {Object}
+ */
+thin.core.ImageShape.prototype.toHash = function() {
+  var hash = this.toHash_();
+
+  // data:image/png;base64,xxxxxxxx
+  var content = this.getFile().getContent();
+  if (/^data:(.+?);base64,(.+)/.test(content)) {
+    goog.object.set(hash, 'data', {
+      'mime-type': RegExp.$1,
+      'base64': RegExp.$2
+    });
+  }
+
+  return hash;
+};
+
+
+/**
+ * @param {Object} attrs
+ */
+thin.core.ImageShape.prototype.update = function(attrs) {
+  this.update_(attrs);
+
+  goog.object.forEach(attrs, function(value, attr) {
+    switch (attr) {
+      case 'data':
+        this.setFile(thin.core.ImageShape.createImageFileFromDataURISchema(value));
+
+        break;
+      default:
+        break;
+      }
+  }, this);
+};
+
+
+/**
+ * @param {Object} factors
+ * @return {thin.core.ImageFile}
+ */
+thin.core.ImageShape.createImageFileFromDataURISchema = function(factors) {
+  var entry = thin.File.createDummyEntry('DummyImageFile');
+  var path = '';
+  // data:<MIME-type>;base64,<base64 data>
+  var content = 'data:' + factors['mime-type'] + ';base64,' + factors['base64'];
+
+  return new thin.core.ImageFile(new thin.File(entry, path, content));
 };

--- a/src/app/core/imageshape.js
+++ b/src/app/core/imageshape.js
@@ -458,23 +458,23 @@ thin.core.ImageShape.prototype.getFill = function() {
 /**
  * @return {Object}
  */
-thin.core.ImageShape.prototype.toHash = function() {
-  var hash = this.toHash_();
+thin.core.ImageShape.prototype.asJSON = function() {
+  var object = this.asJSON_();
 
   // data:image/png;base64,xxxxxxxx
   var content = this.getFile().getContent();
   if (/^data:(.+?);base64,(.+)/.test(content)) {
-    goog.object.set(hash, 'data', {
+    goog.object.set(object, 'data', {
       'mime-type': RegExp.$1,
       'base64': RegExp.$2
     });
   }
 
-  if (goog.object.isEmpty(hash['style'])) {
-    goog.object.remove(hash, 'style');
+  if (goog.object.isEmpty(object['style'])) {
+    goog.object.remove(object, 'style');
   }
 
-  return hash;
+  return object;
 };
 
 
@@ -484,16 +484,9 @@ thin.core.ImageShape.prototype.toHash = function() {
 thin.core.ImageShape.prototype.update = function(attrs) {
   this.update_(attrs);
 
-  goog.object.forEach(attrs, function(value, attr) {
-    switch (attr) {
-      case 'data':
-        this.setFile(thin.core.ImageShape.createImageFileFromDataURISchema(value));
-
-        break;
-      default:
-        break;
-      }
-  }, this);
+  if (goog.object.containsKey(attrs, 'data')) {
+    this.setFile(thin.core.ImageShape.createImageFileFromDataURISchema(attrs['data']));
+  }
 };
 
 

--- a/src/app/core/imageshape.js
+++ b/src/app/core/imageshape.js
@@ -470,6 +470,10 @@ thin.core.ImageShape.prototype.toHash = function() {
     });
   }
 
+  if (goog.object.isEmpty(hash['style'])) {
+    goog.object.remove(hash, 'style');
+  }
+
   return hash;
 };
 

--- a/src/app/core/imageshape.js
+++ b/src/app/core/imageshape.js
@@ -463,10 +463,11 @@ thin.core.ImageShape.prototype.asJSON = function() {
 
   // data:image/png;base64,xxxxxxxx
   var content = this.getFile().getContent();
-  if (/^data:(.+?);base64,(.+)/.test(content)) {
+  var dataUri = content.match(/^data:(.+?);base64,(.+)/);
+  if (dataUri) {
     goog.object.set(object, 'data', {
-      'mime-type': RegExp.$1,
-      'base64': RegExp.$2
+      'mime-type': dataUri[1],
+      'base64': dataUri[2]
     });
   }
 

--- a/src/app/core/layout.js
+++ b/src/app/core/layout.js
@@ -475,7 +475,7 @@ thin.core.Layout.prototype.createHelpersElement = function(tagName, attrs) {
 /**
  * @return {Object}
  */
-thin.core.Layout.prototype.toHash = function() {
+thin.core.Layout.prototype.asJSON = function() {
   var childNodes = this.getCanvasElement().getElement().childNodes;
   var identifiers = goog.array.map(childNodes, function(element, i) {
     return element.getAttribute('id');
@@ -483,7 +483,7 @@ thin.core.Layout.prototype.toHash = function() {
 
   var manager = this.getManager().getShapesManager();
   return goog.array.map(identifiers, function(identifier, i) {
-    return manager.getShapeByIdentifier(identifier).toHash();
+    return manager.getShapeByIdentifier(identifier).asJSON();
   });
 };
 

--- a/src/app/core/layout.js
+++ b/src/app/core/layout.js
@@ -192,28 +192,10 @@ thin.core.Layout.prototype.drawShapeFromElements = function(elements, opt_sectio
  * @param {thin.core.ListSectionShape=} opt_sectionShape
  */
 thin.core.Layout.prototype.drawShapes = function(items, opt_sectionShape) {
-  var shapes = [];
+  var shape;
   goog.array.forEach(items, function(item) {
-    var shape = this.drawShape(item, opt_sectionShape);
-    shapes.push(shape);
+    shape = this.drawShape(item, opt_sectionShape);
   }, this);
-
-  if (opt_sectionShape) {
-    var manager = opt_sectionShape.getManager();
-  } else {
-    var manager = this.getManager();
-  }
-  var shapeIdManager = manager.getShapeIdManager();
-
-  goog.array.forEach(shapes, function(shape, i) {
-    if (shape.instanceOfTblockShape()) {
-      var refId = items[i]['reference-id'];
-      if (!thin.isExactlyEqual(refId, thin.core.TblockShape.DEFAULT_REFID) && thin.isDef(refId)) {
-        shape.setRefId(refId, shapeIdManager.getShapeForShapeId(refId));
-      }
-    }
-  });
-
 };
 
 
@@ -494,7 +476,6 @@ thin.core.Layout.prototype.createHelpersElement = function(tagName, attrs) {
  * @return {Object}
  */
 thin.core.Layout.prototype.toHash = function() {
-  // TODO: DRY
   var childNodes = this.getCanvasElement().getElement().childNodes;
   var identifiers = goog.array.map(childNodes, function(element, i) {
     return element.getAttribute('id');
@@ -981,7 +962,7 @@ thin.core.Layout.prototype.pasteShapes = function() {
           var referringShape = pasteShapes[count];
           if (referringShape.instanceOfTblockShape()) {
             if (!thin.isExactlyEqual(refId, defaultRefId) && !referringShape.isReferences()) {
-              referringShape.setRefId(refId, layout.getShapeForShapeId(refId, shapeIdManager));
+              referringShape.setRefId(refId);
             }
           }
         });
@@ -1000,7 +981,7 @@ thin.core.Layout.prototype.pasteShapes = function() {
           var referringShape = pasteShapes[count];
           if (referringShape.instanceOfTblockShape()) {
             if (!thin.isExactlyEqual(refId, defaultRefId) && !referringShape.isReferences()) {
-              referringShape.setRefId(refId, layout.getShapeForShapeId(refId));
+              referringShape.setRefId(refId);
             }
           }
         });
@@ -1134,23 +1115,23 @@ thin.core.Layout.prototype.removeShape = function(shape) {
       listHelper.clearChangingPageSetShape();
     }
     goog.array.forEach(shape.getPageNumberReferences(), function(target) {
-      target.removeTargetShape();
+      target.removeTargetShapeId();
     });
   }
 
   if (shape.instanceOfTblockShape()) {
     if (shape.isReferences()) {
       goog.array.forEach(shape.getReferringShapes(), function(target) {
-        target.removeReferenceShape();
+        target.removeReferenceShapeId();
       });
     }
     if (shape.isReferring()) {
-      shape.removeReferenceShape();
+      shape.removeReferenceShapeId();
     }
   }
 
   if (shape.instanceOfPageNumberShape()) {
-    shape.removeTargetShape();
+    shape.removeTargetShapeId();
   }
 
   if (shape.isAffiliationListShape()) {
@@ -1386,7 +1367,7 @@ thin.core.Layout.prototype.createTblockShape = function() {
   shape.setFormatType(thin.core.TblockShape.DEFAULT_FORMAT_TYPE);
   shape.setDefaultValueOfLink(thin.core.TblockShape.DEFAULT_VALUE);
   shape.setBaseFormat(thin.core.TblockShape.DEFAULT_FORMAT_BASE);
-  shape.setInternalRefId(thin.core.TblockShape.DEFAULT_REFID);
+  shape.setRefId(thin.core.TblockShape.DEFAULT_REFID);
   shape.setKerning(thin.core.TextStyle.DEFAULT_KERNING);
   shape.setDisplay(thin.core.ModuleShape.DEFAULT_DISPLAY);
   shape.setMultiModeInternal(thin.core.TblockShape.DEFAULT_MULTIPLE);

--- a/src/app/core/layout.js
+++ b/src/app/core/layout.js
@@ -38,7 +38,6 @@ goog.require('thin.core.Helpers');
 goog.require('thin.core.StateManager');
 goog.require('thin.core.ShapeIdManager');
 goog.require('thin.core.ShapeIdManager.DefaultPrefix');
-goog.require('thin.core.LayoutStructure');
 goog.require('thin.core.ClipboardShapeManager');
 
 
@@ -95,10 +94,11 @@ thin.core.Layout.prototype.canvasElement = null;
 
 
 /**
+ * @deprecated
  * @param {Element} element
  */
 thin.core.Layout.prototype.drawListShapeFromElement = function(element) {
-  var shape = thin.core.ListShape.createFromElement(element, this);
+  var shape = thin.core.ShapeStructure.createListShapeFromElement(element, this);
   this.setOutlineForSingle(shape);
   this.manager_.addShape(shape);
   this.appendChild(shape);
@@ -106,6 +106,7 @@ thin.core.Layout.prototype.drawListShapeFromElement = function(element) {
 
 
 /**
+ * @deprecated
  * @param {Element} element
  * @param {thin.core.ListSectionShape=} opt_sectionShape
  */
@@ -125,35 +126,35 @@ thin.core.Layout.prototype.drawBasicShapeFromElement = function(element, opt_sec
 
   switch (this.getElementAttribute(element, 'class')) {
     case thin.core.RectShape.CLASSID:
-      shape = thin.core.RectShape.createFromElement(element, this, opt_shapeIdManager);
+      shape = thin.core.ShapeStructure.createRectShapeFromElement(element, this, opt_shapeIdManager);
       break;
 
     case thin.core.EllipseShape.CLASSID:
-      shape = thin.core.EllipseShape.createFromElement(element, this, opt_shapeIdManager);
+      shape = thin.core.ShapeStructure.createEllipseShapeFromElement(element, this, opt_shapeIdManager);
       break;
 
     case thin.core.LineShape.CLASSID:
-      shape = thin.core.LineShape.createFromElement(element, this, opt_shapeIdManager);
+      shape = thin.core.ShapeStructure.createLineShapeFromElement(element, this, opt_shapeIdManager);
       break;
 
     case thin.core.TblockShape.CLASSID:
-      shape = thin.core.TblockShape.createFromElement(element, this, opt_shapeIdManager);
+      shape = thin.core.ShapeStructure.createTblockShapeFromElement(element, this, opt_shapeIdManager);
       break;
 
     case thin.core.PageNumberShape.CLASSID:
-      shape = thin.core.PageNumberShape.createFromElement(element, this, opt_shapeIdManager);
+      shape = thin.core.ShapeStructure.createPageNumberShapeFromElement(element, this, opt_shapeIdManager);
       break;
 
     case thin.core.TextShape.CLASSID:
-      shape = thin.core.TextShape.createFromElement(element, this, opt_shapeIdManager);
+      shape = thin.core.ShapeStructure.createTextShapeFromElement(element, this, opt_shapeIdManager);
       break;
 
     case thin.core.ImageShape.CLASSID:
-      shape = thin.core.ImageShape.createFromElement(element, this, opt_shapeIdManager);
+      shape = thin.core.ShapeStructure.createImageShapeFromElement(element, this, opt_shapeIdManager);
       break;
 
     case thin.core.ImageblockShape.CLASSID:
-      shape = thin.core.ImageblockShape.createFromElement(element, this, opt_shapeIdManager);
+      shape = thin.core.ShapeStructure.createImageblockShapeFromElement(element, this, opt_shapeIdManager);
       break;
 
     default:
@@ -168,6 +169,7 @@ thin.core.Layout.prototype.drawBasicShapeFromElement = function(element, opt_sec
 
 
 /**
+ * @deprecated
  * @param {NodeList} elements
  * @param {thin.core.ListSectionShape=} opt_sectionShape
  */
@@ -182,6 +184,106 @@ thin.core.Layout.prototype.drawShapeFromElements = function(elements, opt_sectio
       layout.drawBasicShapeFromElement(/** @type {Element} */(element), opt_sectionShape);
     }
   });
+};
+
+
+/**
+ * @param {Object} items
+ * @param {thin.core.ListSectionShape=} opt_sectionShape
+ */
+thin.core.Layout.prototype.drawShapes = function(items, opt_sectionShape) {
+  var shapes = [];
+  goog.array.forEach(items, function(item) {
+    var shape = this.drawShape(item, opt_sectionShape);
+    shapes.push(shape);
+  }, this);
+
+  if (opt_sectionShape) {
+    var manager = opt_sectionShape.getManager();
+  } else {
+    var manager = this.getManager();
+  }
+  var shapeIdManager = manager.getShapeIdManager();
+
+  goog.array.forEach(shapes, function(shape, i) {
+    if (shape.instanceOfTblockShape()) {
+      var refId = items[i]['reference-id'];
+      if (!thin.isExactlyEqual(refId, thin.core.TblockShape.DEFAULT_REFID) && thin.isDef(refId)) {
+        shape.setRefId(refId, shapeIdManager.getShapeForShapeId(refId));
+      }
+    }
+  });
+
+};
+
+
+/**
+ * @param {Object} item
+ * @param {thin.core.ListSectionShape=} opt_sectionShape
+ *
+ * @return {goog.graphics.SvgGroupElement}
+ */
+thin.core.Layout.prototype.drawShape = function(item, opt_sectionShape) {
+  var opt_group;
+  var shape;
+
+  if (opt_sectionShape) {
+    var manager = opt_sectionShape.getManager();
+    opt_group = opt_sectionShape.getGroup();
+  } else {
+    var manager = this.getManager();
+  }
+
+  switch (item['type']) {
+    case 'rect':
+      shape = this.createRectShape();
+      break;
+
+    case 'ellipse':
+      shape = this.createEllipseShape();
+      break;
+
+    case 'line':
+      shape = this.createLineShape();
+      break;
+
+    case 'text-block':
+      shape = this.createTblockShape();
+      break;
+
+    case 'page-number':
+      shape = this.createPageNumberShape();
+      break;
+
+    case 'text':
+      shape = this.createTextShape();
+      break;
+
+    case 'image':
+      shape = this.createImageShape();
+      break;
+
+    case 'image-block':
+      shape = this.createImageblockShape();
+      break;
+
+    case 'list':
+      shape = this.createListShape();
+      break;
+
+    default:
+      throw new Error('Unknown shape.');
+      break;
+  }
+
+  this.setOutlineForSingle(shape);
+  manager.addShape(shape, opt_sectionShape);
+  this.appendChild(shape, opt_group);
+  shape.setupEventHandlers();
+
+  shape.update(item);
+
+  return shape;
 };
 
 
@@ -389,10 +491,19 @@ thin.core.Layout.prototype.createHelpersElement = function(tagName, attrs) {
 
 
 /**
- * @return {string}
+ * @return {Object}
  */
-thin.core.Layout.prototype.toXML = function() {
-  return thin.core.LayoutStructure.serialize(this);
+thin.core.Layout.prototype.toHash = function() {
+  // TODO: DRY
+  var childNodes = this.getCanvasElement().getElement().childNodes;
+  var identifiers = goog.array.map(childNodes, function(element, i) {
+    return element.getAttribute('id');
+  });
+
+  var manager = this.getManager().getShapesManager();
+  return goog.array.map(identifiers, function(identifier, i) {
+    return manager.getShapeByIdentifier(identifier).toHash();
+  });
 };
 
 

--- a/src/app/core/layoutstructure.js
+++ b/src/app/core/layoutstructure.js
@@ -20,6 +20,7 @@ goog.require('thin.platform.String');
 
 
 /**
+ * @deprecated
  * @enum {string}
  * @private
  */
@@ -31,6 +32,7 @@ thin.core.LayoutStructure.Template_ = {
 
 
 /**
+ * @deprecated
  * @enum {RegExp}
  * @private
  */
@@ -52,6 +54,7 @@ thin.core.LayoutStructure.restoreStructure = function(svg) {
 
 
 /**
+ * @deprecated
  * @param {thin.core.Layout} layout
  * @return {string} The base64 encoded string.
  */
@@ -129,12 +132,13 @@ thin.core.LayoutStructure.finalizeLayoutElement_ = function(layoutElement) {
 
 
 /**
+ * @deprecated
  * @param {thin.core.Layout} layout
  */
 thin.core.LayoutStructure.convertToNewLayoutSchema = function(layout) {
   var format = layout.getFormat();
 
-  var xmlString = thin.core.LayoutStructure.restoreStructure(format.getSvg());
+  var xmlString = thin.core.LayoutStructure.restoreStructure(format.getItems());
   var doc = new DOMParser().parseFromString(xmlString, "application/xml");
   var canvasNode = goog.dom.getLastElementChild(doc.documentElement);
 
@@ -143,12 +147,13 @@ thin.core.LayoutStructure.convertToNewLayoutSchema = function(layout) {
   var shapes = layout.getManager().getShapesManager().get();
   thin.core.LayoutStructure.applyRefId(layout, shapes);
 
-  format.setSvg(layout.toHash());
+  format.setItems(layout.asJSON());
   layout.removeShapes(shapes);
 };
 
 
 /**
+ * @deprecated
  * @param {thin.core.Layout} layout
  * @param {Array} shapes
  * @param {thin.core.ListSectionShape=} opt_shapeIdManager

--- a/src/app/core/layoutstructure.js
+++ b/src/app/core/layoutstructure.js
@@ -57,26 +57,14 @@ thin.core.LayoutStructure.restoreStructure = function(svg) {
  */
 thin.core.LayoutStructure.createScreenShot = function(layout) {
   var svg;
-  
+
   thin.core.LayoutStructure.inRawLayout_(layout, function() {
     svg = layout.getElement().cloneNode(true);
   });
   thin.core.LayoutStructure.finalizeLayoutElement_(svg);
-  
+
   return thin.platform.String.toBase64(
       thin.core.serializeToXML(/** @type {Element} */ (svg)));
-};
-
-
-/**
- * @param {thin.core.Layout} layout
- * @return {string}
- */
-thin.core.LayoutStructure.createBackup = function(layout) {
-  var svg = layout.getElement().cloneNode(true);
-  thin.core.LayoutStructure.finalizeLayoutElement_(svg);
-
-  return thin.core.serializeToXML(/** @type {Element} */(svg));
 };
 
 
@@ -90,7 +78,7 @@ thin.core.LayoutStructure.inRawLayout_ = function(layout, f) {
   var workspace = layout.getWorkspace();
   var zoomRate = workspace.getUiStatusForZoom();
   var listHelper = layout.getHelpers().getListHelper();
-  
+
   // Set zoom-rate to 100%.
   var scrollTarget = workspace.getParent().getParent().getContentElement();
   var scrollLeft = Number(scrollTarget.scrollLeft);
@@ -108,15 +96,15 @@ thin.core.LayoutStructure.inRawLayout_ = function(layout, f) {
       shapes: listHelper.getActiveShape().getClone()
     };
     listHelper.inactive();
-    
+
     f();
-    
+
     // Activate list and restore states.
     listHelper.active(listStates.target);
     listHelper.getActiveShape().set(listStates.shapes);
     listHelper.setActiveSectionName(listStates.activeSection);
   }
-  
+
   // Restore original zoom-rate.
   workspace.getAction().actionSetZoom(zoomRate);
   scrollTarget.scrollLeft = scrollLeft;
@@ -131,7 +119,7 @@ thin.core.LayoutStructure.inRawLayout_ = function(layout, f) {
  */
 thin.core.LayoutStructure.finalizeLayoutElement_ = function(layoutElement) {
   var canvasId = thin.core.Layout.CANVAS_CLASS_ID;
-  
+
   goog.array.forEachRight(layoutElement.childNodes, function(node, i, nodes) {
     if (canvasId != node.getAttribute('class')) {
       layoutElement.removeChild(nodes[i]);
@@ -178,7 +166,7 @@ thin.core.LayoutStructure.applyRefId = function(layout, shapes, opt_shapeIdManag
       if (shape.instanceOfTblockShape()) {
         var refId = layout.getElementAttribute(shape.getElement(), 'x-ref-id');
         if (!thin.isExactlyEqual(refId, thin.core.TblockShape.DEFAULT_REFID)) {
-          shape.setRefId(refId, layout.getShapeForShapeId(refId, opt_shapeIdManager));
+          shape.setRefId(refId);
         }
       }
     }

--- a/src/app/core/lineshape.js
+++ b/src/app/core/lineshape.js
@@ -58,28 +58,6 @@ thin.core.LineShape.prototype.getClassId = function() {
 };
 
 
-/**
- * @param {Element} element
- * @param {thin.core.Layout} layout
- * @param {thin.core.ShapeIdManager=} opt_shapeIdManager
- * @return {thin.core.LineShape}
- */
-thin.core.LineShape.createFromElement = function(element, layout, opt_shapeIdManager) {
-
-  var shape = new thin.core.LineShape(element, layout, 
-                  new goog.graphics.Stroke(
-                      Number(layout.getElementAttribute(element, 'stroke-width')),
-                      layout.getElementAttribute(element, 'stroke')));
-  
-  shape.setShapeId(layout.getElementAttribute(element, 'x-id'), opt_shapeIdManager);
-  shape.setDisplay(layout.getElementAttribute(element, 'x-display') == 'true');
-  shape.setDesc(layout.getElementAttribute(element, 'x-desc'));
-  shape.setStrokeDashFromType(layout.getElementAttribute(element, 'x-stroke-type'));
-  shape.initIdentifier();
-  return shape;
-};
-
-
 thin.core.LineShape.prototype.setDefaultOutline = function() {
   this.setTargetOutline(this.getLayout().getHelpers().getLineOutline());
 };
@@ -350,4 +328,61 @@ thin.core.LineShape.prototype.setInitShapeProperties = function(properties) {
 thin.core.LineShape.prototype.disposeInternal = function() {
   thin.core.LineShape.superClass_.disposeInternal.call(this);
   this.disposeInternalForShape();
+};
+
+
+/**
+ * @return {Object}
+ */
+thin.core.LineShape.prototype.toHash = function() {
+  var hash = this.toHash_();
+
+  var layout  = this.getLayout();
+  var element = this.getElement();
+  goog.object.extend(hash, {
+    'x1': Number(layout.getElementAttribute(element, 'x1')),
+    'y1': Number(layout.getElementAttribute(element, 'y1')),
+    'x2': Number(layout.getElementAttribute(element, 'x2')),
+    'y2': Number(layout.getElementAttribute(element, 'y2'))
+  });
+
+  goog.object.remove(hash, 'x');
+  goog.object.remove(hash, 'y');
+  goog.object.remove(hash, 'width');
+  goog.object.remove(hash, 'height');
+
+  return hash;
+};
+
+
+/**
+ * @param {Object} attrs
+ */
+thin.core.LineShape.prototype.update = function(attrs) {
+  this.update_(attrs);
+
+  var keys = goog.object.getKeys(attrs);
+  var result_index = goog.array.findIndex(keys, function(key, index) {
+    return key == 'x1' || key == 'x2' || key == 'y1' || key == 'y2'
+  });
+
+  if (result_index > -1) {
+    var x1 = attrs['x1'];
+    var x2 = attrs['x2'];
+    var y1 = attrs['y1'];
+    var y2 = attrs['y2'];
+
+    this.setX1(x1);
+    this.setX2(x2);
+    this.setY1(y1);
+    this.setY2(y2);
+
+    this.calculateDirection(y1, y2);
+
+    this.setLeft(Math.min(x1, x2));
+    this.setTop(Math.min(y1, y2));
+    this.setWidth(Math.abs(x1 - x2));
+    this.setHeight(Math.abs(y1 - y2));
+  }
+
 };

--- a/src/app/core/lineshape.js
+++ b/src/app/core/lineshape.js
@@ -334,24 +334,24 @@ thin.core.LineShape.prototype.disposeInternal = function() {
 /**
  * @return {Object}
  */
-thin.core.LineShape.prototype.toHash = function() {
-  var hash = this.toHash_();
+thin.core.LineShape.prototype.asJSON = function() {
+  var object = this.asJSON_();
 
   var layout  = this.getLayout();
   var element = this.getElement();
-  goog.object.extend(hash, {
+  goog.object.extend(object, {
     'x1': Number(layout.getElementAttribute(element, 'x1')),
     'y1': Number(layout.getElementAttribute(element, 'y1')),
     'x2': Number(layout.getElementAttribute(element, 'x2')),
     'y2': Number(layout.getElementAttribute(element, 'y2'))
   });
 
-  goog.object.remove(hash, 'x');
-  goog.object.remove(hash, 'y');
-  goog.object.remove(hash, 'width');
-  goog.object.remove(hash, 'height');
+  goog.object.remove(object, 'x');
+  goog.object.remove(object, 'y');
+  goog.object.remove(object, 'width');
+  goog.object.remove(object, 'height');
 
-  return hash;
+  return object;
 };
 
 

--- a/src/app/core/lineshape.js
+++ b/src/app/core/lineshape.js
@@ -90,7 +90,7 @@ thin.core.LineShape.prototype.getCloneCreator = function() {
   var fill = this.getFill();
   var strokeDashType = this.getStrokeDashType();
   var display = this.getDisplay();
-  
+
   var isAffiliationListShape = this.isAffiliationListShape();
   var deltaCoordinate = this.getDeltaCoordinateForList();
 
@@ -102,10 +102,10 @@ thin.core.LineShape.prototype.getCloneCreator = function() {
    * @return {thin.core.LineShape}
    */
   return function(layout, opt_isAdaptDeltaForList, opt_renderTo, opt_basisCoordinate) {
-  
+
     var shape = layout.createLineShape();
     layout.appendChild(shape, opt_renderTo);
-    
+
     var pasteCoordinate = layout.calculatePasteCoordinate(isAffiliationListShape,
           deltaCoordinateForList, deltaCoordinateForGuide, sourceCoordinate,
           opt_isAdaptDeltaForList, opt_renderTo, opt_basisCoordinate);
@@ -127,62 +127,62 @@ thin.core.LineShape.prototype.getCloneCreator = function() {
  * @private
  */
 thin.core.LineShape.prototype.createPropertyComponent_ = function() {
-  
+
   var scope = this;
   var layout = this.getLayout();
   var propEventType = thin.ui.PropertyPane.Property.EventType;
   var proppane = thin.ui.getComponent('proppane');
-  
+
   var baseGroup = proppane.addGroup(thin.t('property_group_basis'));
-  
-  
+
+
   var leftInputProperty = new thin.ui.PropertyPane.NumberInputProperty(thin.t('field_left_position'));
   var leftInput = leftInputProperty.getValueControl();
   leftInput.getNumberValidator().setAllowDecimal(true, 1);
-  
+
   leftInputProperty.addEventListener(propEventType.CHANGE,
       this.setLeftForPropertyUpdate, false, this);
-  
+
   proppane.addProperty(leftInputProperty, baseGroup, 'left');
 
 
   var topInputProperty = new thin.ui.PropertyPane.NumberInputProperty(thin.t('field_top_position'));
   var topInput = topInputProperty.getValueControl();
   topInput.getNumberValidator().setAllowDecimal(true, 1);
-  
+
   topInputProperty.addEventListener(propEventType.CHANGE,
       this.setTopForPropertyUpdate, false, this);
-  
+
   proppane.addProperty(topInputProperty, baseGroup, 'top');
-  
-  
+
+
   var widthInputProperty = new thin.ui.PropertyPane.NumberInputProperty(thin.t('field_width'));
   var widthInput = widthInputProperty.getValueControl();
   widthInput.getNumberValidator().setAllowDecimal(true, 1);
-  
+
   widthInputProperty.addEventListener(propEventType.CHANGE,
       this.setWidthForPropertyUpdate, false, this);
-  
+
   proppane.addProperty(widthInputProperty, baseGroup, 'width');
-  
-  
+
+
   var heightInputProperty = new thin.ui.PropertyPane.NumberInputProperty(thin.t('field_height'));
   var heightInput = heightInputProperty.getValueControl();
   heightInput.getNumberValidator().setAllowDecimal(true, 1);
-  
+
   heightInputProperty.addEventListener(propEventType.CHANGE,
       this.setHeightForPropertyUpdate, false, this);
-  
+
   proppane.addProperty(heightInputProperty, baseGroup, 'height');
-  
-  
+
+
   var displayCheckProperty = new thin.ui.PropertyPane.CheckboxProperty(thin.t('field_display'));
   displayCheckProperty.addEventListener(propEventType.CHANGE,
       this.setDisplayForPropertyUpdate, false, this);
-  
+
   proppane.addProperty(displayCheckProperty, baseGroup, 'display');
 
-  
+
   var shapeGroup = proppane.addGroup(thin.t('property_group_shape'));
 
 
@@ -190,10 +190,10 @@ thin.core.LineShape.prototype.createPropertyComponent_ = function() {
   strokeInputProperty.getValueControl().getInput().setLabel('none');
   strokeInputProperty.addEventListener(propEventType.CHANGE,
       this.setStrokeForPropertyUpdate, false, this);
-  
+
   proppane.addProperty(strokeInputProperty , shapeGroup, 'stroke');
-  
-  
+
+
   var strokeWidthCombProperty = new thin.ui.PropertyPane.ComboBoxProperty(thin.t('field_stroke_width'));
   var strokeWidthComb = strokeWidthCombProperty.getValueControl();
   var strokeWidthInput = strokeWidthComb.getInput();
@@ -212,10 +212,10 @@ thin.core.LineShape.prototype.createPropertyComponent_ = function() {
   });
   strokeWidthCombProperty.addEventListener(propEventType.CHANGE,
       this.setStrokeWidthForPropertyUpdate, false, this);
-  
+
   proppane.addProperty(strokeWidthCombProperty , shapeGroup, 'stroke-width');
 
-  
+
   var strokeType = thin.core.ModuleElement.StrokeType;
   var strokeDashSelectProperty = new thin.ui.PropertyPane.SelectProperty(thin.t('field_stroke_type'));
   var strokeDashSelect = strokeDashSelectProperty.getValueControl();
@@ -228,25 +228,25 @@ thin.core.LineShape.prototype.createPropertyComponent_ = function() {
       new thin.ui.Option(thin.core.ModuleElement.getStrokeName(strokeType.DASHED), strokeType.DASHED));
   strokeDashSelect.addItem(
       new thin.ui.Option(thin.core.ModuleElement.getStrokeName(strokeType.DOTTED), strokeType.DOTTED));
-  
+
   strokeDashSelectProperty.addEventListener(propEventType.CHANGE,
       this.setStrokeDashTypeForPropertyUpdate, false, this);
-  
+
   proppane.addProperty(strokeDashSelectProperty , shapeGroup, 'stroke-dash-type');
 
 
   var cooperationGroup = proppane.addGroup(thin.t('property_group_association'));
-  
+
   var idInputProperty = new thin.ui.PropertyPane.IdInputProperty(this, 'ID');
   idInputProperty.addEventListener(propEventType.CHANGE,
       this.setShapeIdForPropertyUpdate, false, this);
-  
+
   proppane.addProperty(idInputProperty, cooperationGroup, 'shape-id');
-  
+
   var descProperty = new thin.ui.PropertyPane.InputProperty(thin.t('field_description'));
   descProperty.addEventListener(propEventType.CHANGE,
       this.setDescPropertyUpdate, false, this);
-  
+
   proppane.addProperty(descProperty, cooperationGroup, 'desc');
 };
 
@@ -279,16 +279,16 @@ thin.core.LineShape.prototype.updateProperties = function() {
     proppane.setTarget(this);
     this.createPropertyComponent_();
   }
-  
+
   var properties = this.getProperties();
   var proppaneBlank = thin.core.ModuleShape.PROPPANE_SHOW_BLANK;
-  
+
   proppane.getPropertyControl('left').setValue(properties['left']);
   proppane.getPropertyControl('top').setValue(properties['top']);
   proppane.getPropertyControl('width').setValue(properties['width']);
   proppane.getPropertyControl('height').setValue(properties['height']);
   proppane.getPropertyControl('display').setChecked(properties['display']);
-  
+
   var stroke = properties['stroke'];
   if (thin.isExactlyEqual(stroke, thin.core.ModuleShape.NONE)) {
     stroke = proppaneBlank
@@ -299,9 +299,9 @@ thin.core.LineShape.prototype.updateProperties = function() {
     strokeWidth = proppaneBlank;
   }
   proppane.getPropertyControl('stroke-width').setInternalValue(strokeWidth);
-  
+
   proppane.getPropertyControl('stroke-dash-type').setValue(properties['stroke-dash-type']);
-  
+
   proppane.getPropertyControl('shape-id').setValue(properties['shape-id']);
   proppane.getPropertyControl('desc').setValue(properties['desc']);
 };
@@ -379,8 +379,8 @@ thin.core.LineShape.prototype.update = function(attrs) {
 
     this.calculateDirection(y1, y2);
 
-    this.setLeft(Math.min(x1, x2));
-    this.setTop(Math.min(y1, y2));
+    this.setLeft(Math.min(x1, x2) + this.getParentTransLateX());
+    this.setTop(Math.min(y1, y2) + this.getParentTransLateY());
     this.setWidth(Math.abs(x1 - x2));
     this.setHeight(Math.abs(y1 - y2));
   }

--- a/src/app/core/listsectionshape.js
+++ b/src/app/core/listsectionshape.js
@@ -334,8 +334,8 @@ thin.core.ListSectionShape.prototype.getType = function() {
 /**
  * @return {Object}
  */
-thin.core.ListSectionShape.prototype.toHash = function() {
-  var hash = {
+thin.core.ListSectionShape.prototype.asJSON = function() {
+  var object = {
     'enabled': this.isEnabled(),
     'height': this.height_
   };
@@ -350,13 +350,13 @@ thin.core.ListSectionShape.prototype.toHash = function() {
 
     var manager = this.getManager().getShapesManager();
     var items = goog.array.map(identifiers, function(identifier, i) {
-      return manager.getShapeByIdentifier(identifier).toHash();
+      return manager.getShapeByIdentifier(identifier).asJSON();
     });
   } else {
     var items = [];
   }
 
-  goog.object.extend(hash, {
+  goog.object.extend(object, {
     'translate': {
       'x': transform.getTranslateX(),
       'y': transform.getTranslateY()
@@ -364,7 +364,7 @@ thin.core.ListSectionShape.prototype.toHash = function() {
     'items': items
   });
 
-  return hash;
+  return object;
 };
 
 
@@ -555,12 +555,12 @@ thin.core.DetailSectionShape.prototype.updateProperties = function() {
 /**
  * @return {Object}
  */
-thin.core.DetailSectionShape.prototype.toHash = function() {
-  var hash = goog.base(this, 'toHash');
+thin.core.DetailSectionShape.prototype.asJSON = function() {
+  var object = goog.base(this, 'asJSON');
 
-  goog.object.remove(hash, 'enabled');
+  goog.object.remove(object, 'enabled');
 
-  return hash;
+  return object;
 };
 
 

--- a/src/app/core/listsectionshape.js
+++ b/src/app/core/listsectionshape.js
@@ -38,19 +38,19 @@ goog.require('thin.core.ModuleShape');
  * @extends {goog.Disposable}
  */
 thin.core.ListSectionShape = function(layout, affiliationGroup, sectionName, opt_element) {
-  
+
   /**
    * @type {thin.core.Layout}
    * @private
    */
   this.layout_ = layout;
-  
+
   /**
    * @type {thin.core.ListShape}
    * @private
    */
   this.affiliationGroup_ = affiliationGroup;
-  
+
   /**
    * @type {string}
    * @private
@@ -138,7 +138,7 @@ thin.core.ListSectionShape.prototype.setup = function(opt_element) {
                         'class': thin.core.ListShape.CLASSID + classId[this.sectionName_]
                       }), layout);
   group.setTransformation(0, 0, 0, 0, 0);
-  
+
   this.group_ = group;
 
   this.manager_ = new thin.core.StateManager(layout);
@@ -173,7 +173,7 @@ thin.core.ListSectionShape.prototype.setEnabled = function(enabled) {
  * @return {boolean}
  */
 thin.core.ListSectionShape.prototype.isEnabled = function() {
-  return /** @type {boolean} */(thin.getValIfNotDef(this.isEnabled_, 
+  return /** @type {boolean} */(thin.getValIfNotDef(this.isEnabled_,
              thin.core.ListSectionShape.DEFAULT_ENABLED));
 };
 
@@ -286,7 +286,7 @@ thin.core.ListSectionShape.prototype.getNextSectionShape = function() {
  */
 thin.core.ListSectionShape.prototype.getNextSectionShapes = function() {
   var sectionShapes = [];
-  
+
   /**
    * @param {thin.core.ListSectionShape=} opt_sectionShape
    */
@@ -317,12 +317,80 @@ thin.core.ListSectionShape.prototype.disposeInternal = function() {
   thin.core.ListSectionShape.superClass_.disposeInternal.call(this);
   this.group_.dispose();
   this.manager_.dispose();
-  
+
   delete this.group_;
   delete this.manager_;
   delete this.affiliationGroup_;
   delete this.nextSectionShape_;
   delete this.previousSectionShape_;
+};
+
+
+thin.core.ListSectionShape.prototype.getType = function() {
+  return thin.core.ListShape.ClassIds[this.getSectionName()].replace(/^\-/, '');
+};
+
+
+/**
+ * @return {Object}
+ */
+thin.core.ListSectionShape.prototype.toHash = function() {
+  var hash = {
+    'enabled': this.isEnabled(),
+    'height': this.height_
+  };
+
+  var transform = this.getGroup().getTransform();
+
+  if (this.isEnabled()) {
+    var childNodes = this.getGroup().getElement().childNodes;
+    var identifiers = goog.array.map(childNodes, function(element, i) {
+      return element.getAttribute('id');
+    });
+
+    var manager = this.getManager().getShapesManager();
+    var items = goog.array.map(identifiers, function(identifier, i) {
+      return manager.getShapeByIdentifier(identifier).toHash();
+    });
+  } else {
+    var items = [];
+  }
+
+  goog.object.extend(hash, {
+    'translate': {
+      'x': transform.getTranslateX(),
+      'y': transform.getTranslateY()
+    },
+    'items': items
+  });
+
+  return hash;
+};
+
+
+/**
+ * @param {Object} attrs
+ */
+thin.core.ListSectionShape.prototype.update = function(attrs) {
+  goog.object.forEach(attrs, function(value, attr) {
+    switch (attr) {
+      case 'enabled':
+        this.setEnabled(value);
+        break;
+      case 'height':
+        this.setHeight(value);
+        break;
+      case 'translate':
+        this.setTransLate(new goog.math.Coordinate(
+          value['x'], value['y']));
+        break;
+      case 'items':
+        this.getLayout().drawShapes(value, this);
+        break;
+      default:
+        break;
+      }
+  }, this);
 };
 
 
@@ -357,7 +425,7 @@ thin.core.HeaderSectionShape.prototype.defaultHeightRate_ = 0.2;
  * @return {boolean}
  */
 thin.core.HeaderSectionShape.prototype.isEnabled = function() {
-  return /** @type {boolean} */(thin.getValIfNotDef(this.isEnabled_, 
+  return /** @type {boolean} */(thin.getValIfNotDef(this.isEnabled_,
              thin.core.HeaderSectionShape.DEFAULT_ENABLED));
 };
 
@@ -372,28 +440,28 @@ thin.core.HeaderSectionShape.prototype.createPropertyComponent_ = function() {
   var sectionName = this.sectionName_;
   var propEventType = thin.ui.PropertyPane.Property.EventType;
   var proppane = thin.ui.getComponent('proppane');
-  
+
   var containerGroup = proppane.addGroup(thin.t('property_group_list_header'));
-  
+
   var heightInputProperty = new thin.ui.PropertyPane.NumberInputProperty(thin.t('field_height'));
   var heightInput = heightInputProperty.getValueControl();
   heightInput.getNumberValidator().setAllowDecimal(true, 1);
-  
+
   heightInputProperty.addEventListener(propEventType.CHANGE,
       function(e) {
         listShape.setHeightForSectionShape(
             Number(e.target.getValue()), sectionName);
       }, false, this);
-  
+
   proppane.addProperty(heightInputProperty, containerGroup, 'section-header-height');
-  
-  
+
+
   var displayCheckProperty = new thin.ui.PropertyPane.CheckboxProperty(thin.t('field_display'));
   displayCheckProperty.addEventListener(propEventType.CHANGE,
       function(e) {
         scope.setSectionEnabled(e.target.isChecked(), sectionName);
       }, false, this);
-  
+
   proppane.addProperty(displayCheckProperty, containerGroup, 'section-header-enable');
 };
 
@@ -441,7 +509,7 @@ thin.core.DetailSectionShape.prototype.defaultHeightRate_ = 0.2;
  * @return {boolean}
  */
 thin.core.DetailSectionShape.prototype.isEnabled = function() {
-  return /** @type {boolean} */(thin.getValIfNotDef(this.isEnabled_, 
+  return /** @type {boolean} */(thin.getValIfNotDef(this.isEnabled_,
              thin.core.DetailSectionShape.DEFAULT_ENABLED));
 };
 
@@ -456,19 +524,19 @@ thin.core.DetailSectionShape.prototype.createPropertyComponent_ = function() {
   var sectionName = this.sectionName_;
   var propEventType = thin.ui.PropertyPane.Property.EventType;
   var proppane = thin.ui.getComponent('proppane');
-  
+
   var containerGroup = proppane.addGroup(thin.t('property_group_list_detail'));
-  
+
   var heightInputProperty = new thin.ui.PropertyPane.NumberInputProperty(thin.t('field_height'));
   var heightInput = heightInputProperty.getValueControl();
   heightInput.getNumberValidator().setAllowDecimal(true, 1);
-  
+
   heightInputProperty.addEventListener(propEventType.CHANGE,
       function(e) {
         listShape.setHeightForSectionShape(
             Number(e.target.getValue()), sectionName);
       }, false, this);
-  
+
   proppane.addProperty(heightInputProperty, containerGroup, 'section-detail-height');
 };
 
@@ -481,6 +549,18 @@ thin.core.DetailSectionShape.prototype.updateProperties = function() {
     this.createPropertyComponent_();
   }
   proppane.getPropertyControl('section-detail-height').setValue(this.height_);
+};
+
+
+/**
+ * @return {Object}
+ */
+thin.core.DetailSectionShape.prototype.toHash = function() {
+  var hash = goog.base(this, 'toHash');
+
+  goog.object.remove(hash, 'enabled');
+
+  return hash;
 };
 
 
@@ -515,7 +595,7 @@ thin.core.PageFooterSectionShape.prototype.defaultHeightRate_ = 0.15;
  * @return {boolean}
  */
 thin.core.PageFooterSectionShape.prototype.isEnabled = function() {
-  return /** @type {boolean} */(thin.getValIfNotDef(this.isEnabled_, 
+  return /** @type {boolean} */(thin.getValIfNotDef(this.isEnabled_,
              thin.core.PageFooterSectionShape.DEFAULT_ENABLED));
 };
 
@@ -530,28 +610,28 @@ thin.core.PageFooterSectionShape.prototype.createPropertyComponent_ = function()
   var sectionName = this.sectionName_;
   var propEventType = thin.ui.PropertyPane.Property.EventType;
   var proppane = thin.ui.getComponent('proppane');
-  
+
   var containerGroup = proppane.addGroup(thin.t('property_group_list_page_footer'));
-  
+
   var heightInputProperty = new thin.ui.PropertyPane.NumberInputProperty(thin.t('field_height'));
   var heightInput = heightInputProperty.getValueControl();
   heightInput.getNumberValidator().setAllowDecimal(true, 1);
-  
+
   heightInputProperty.addEventListener(propEventType.CHANGE,
       function(e) {
         listShape.setHeightForSectionShape(
             Number(e.target.getValue()), sectionName);
       }, false, this);
-  
+
   proppane.addProperty(heightInputProperty, containerGroup, 'section-pagefooter-height');
-  
-  
+
+
   var displayCheckProperty = new thin.ui.PropertyPane.CheckboxProperty(thin.t('field_display'));
   displayCheckProperty.addEventListener(propEventType.CHANGE,
       function(e) {
         scope.setSectionEnabled(e.target.isChecked(), sectionName);
       }, false, this);
-  
+
   proppane.addProperty(displayCheckProperty, containerGroup, 'section-pagefooter-enable');
 };
 
@@ -599,7 +679,7 @@ thin.core.FooterSectionShape.prototype.defaultHeightRate_ = 0.15;
  * @return {boolean}
  */
 thin.core.FooterSectionShape.prototype.isEnabled = function() {
-  return /** @type {boolean} */(thin.getValIfNotDef(this.isEnabled_, 
+  return /** @type {boolean} */(thin.getValIfNotDef(this.isEnabled_,
              thin.core.FooterSectionShape.DEFAULT_ENABLED));
 };
 
@@ -614,28 +694,28 @@ thin.core.FooterSectionShape.prototype.createPropertyComponent_ = function() {
   var sectionName = this.sectionName_;
   var propEventType = thin.ui.PropertyPane.Property.EventType;
   var proppane = thin.ui.getComponent('proppane');
-  
+
   var containerGroup = proppane.addGroup(thin.t('property_group_list_footer'));
-  
+
   var heightInputProperty = new thin.ui.PropertyPane.NumberInputProperty(thin.t('field_height'));
   var heightInput = heightInputProperty.getValueControl();
   heightInput.getNumberValidator().setAllowDecimal(true, 1);
-  
+
   heightInputProperty.addEventListener(propEventType.CHANGE,
       function(e) {
         listShape.setHeightForSectionShape(
             Number(e.target.getValue()), sectionName);
       }, false, this);
-  
+
   proppane.addProperty(heightInputProperty, containerGroup, 'section-footer-height');
-  
-  
+
+
   var displayCheckProperty = new thin.ui.PropertyPane.CheckboxProperty(thin.t('field_display'));
   displayCheckProperty.addEventListener(propEventType.CHANGE,
       function(e) {
         scope.setSectionEnabled(e.target.isChecked(), sectionName);
       }, false, this);
-  
+
   proppane.addProperty(displayCheckProperty, containerGroup, 'section-footer-enable');
 };
 

--- a/src/app/core/listshape.js
+++ b/src/app/core/listshape.js
@@ -903,25 +903,25 @@ thin.core.ListShape.prototype.getType = function() {
 /**
  * @return {Object}
  */
-thin.core.ListShape.prototype.toHash = function() {
-  var hash = this.toHash_();
+thin.core.ListShape.prototype.asJSON = function() {
+  var object = this.asJSON_();
   var header = this.getSectionShape(
     thin.core.ListHelper.SectionName.HEADER);
 
   this.forEachSectionShape(function(section, name) {
-    goog.object.set(hash, section.getType(), section.toHash());
+    goog.object.set(object, section.getType(), section.asJSON());
   });
 
-  goog.object.extend(hash, {
+  goog.object.extend(object, {
     'content-height': this.getHeight() - header.getHeight(),
     'auto-page-break': this.isChangingPage()
   });
 
-  if (goog.object.isEmpty(hash['style'])) {
-    goog.object.remove(hash, 'style');
+  if (goog.object.isEmpty(object['style'])) {
+    goog.object.remove(object, 'style');
   }
 
-  return hash;
+  return object;
 };
 
 

--- a/src/app/core/listshape.js
+++ b/src/app/core/listshape.js
@@ -855,26 +855,21 @@ thin.core.ListShape.prototype.updateProperties = function() {
 
 
 /**
- * @param {thin.core.PageNumberShape} pageNumber
- */
-thin.core.ListShape.prototype.setPageNumberReference = function(pageNumber) {
-  goog.array.insert(this.pageNumberReferences_, pageNumber);
-};
-
-
-/**
  * @return {Array.<thin.core.PageNumberShape>}
  */
 thin.core.ListShape.prototype.getPageNumberReferences = function() {
-  return goog.array.clone(this.pageNumberReferences_);
-};
+  var refereces = [];
+  var shapeId = this.getShapeId();
 
+  var layout = this.getLayout();
+  layout.forPageNumberShapesEach(
+    layout.getManager().getShapesManager().get(), function(shape, i) {
+      if (thin.isExactlyEqual(shapeId, shape.getTargetId())) {
+        goog.array.insert(refereces, shape);
+      }
+    });
 
-/**
- * @param {thin.core.PageNumberShape} pageNumber
- */
-thin.core.ListShape.prototype.removePageNumberReference = function(pageNumber) {
-  goog.array.remove(this.pageNumberReferences_, pageNumber);
+  return goog.array.clone(refereces);
 };
 
 
@@ -921,6 +916,10 @@ thin.core.ListShape.prototype.toHash = function() {
     'content-height': this.getHeight() - header.getHeight(),
     'auto-page-break': this.isChangingPage()
   });
+
+  if (goog.object.isEmpty(hash['style'])) {
+    goog.object.remove(hash, 'style');
+  }
 
   return hash;
 };

--- a/src/app/core/moduleshape.js
+++ b/src/app/core/moduleshape.js
@@ -175,6 +175,21 @@ thin.core.ModuleShape.prototype.setStrokeWidth = function(width) {
 
 /**
  * @this {goog.graphics.Element}
+ * @param {string?} color
+ */
+thin.core.ModuleShape.prototype.setStrokeColor = function(color) {
+  var strokeNone = thin.core.ModuleShape.NONE;
+
+  var strokeColor = /** @type {string} */(thin.getValIfNotDef(color, ''));
+  var stroke = new goog.graphics.Stroke(this.getStroke().getWidth(),
+    thin.isExactlyEqual(strokeColor, '') ? strokeNone : strokeColor);
+
+  this.setStroke(stroke);
+};
+
+
+/**
+ * @this {goog.graphics.Element}
  * @param {string} shapeId
  */
 thin.core.ModuleShape.prototype.setShapeIdInternal = function(shapeId) {
@@ -1222,4 +1237,119 @@ thin.core.ModuleShape.prototype.setSectionEnabled = function(
  */
 thin.core.ModuleShape.prototype.isIntersects = function(judgement_box) {
   return goog.math.Box.intersects(judgement_box, this.getBoxSize());
+};
+
+
+/**
+ * @this {goog.graphics.Element}
+ * @param {string?} color
+ */
+thin.core.ModuleShape.prototype.setFillColor = function(color) {
+  var fillNone = thin.core.ModuleShape.NONE;
+
+  var fillColor = /** @type {string} */(thin.getValIfNotDef(color, ''));
+  var fill = new goog.graphics.SolidFill(
+    thin.isExactlyEqual(fillColor, '') ? fillNone : fillColor);
+
+  this.setFill(fill);
+};
+
+
+/**
+ * @this {goog.graphics.Element}
+ * @return {string}
+ */
+thin.core.ModuleShape.prototype.getType = function() {
+  return this.getElement().tagName;
+};
+
+
+/**
+ * @private
+ * @this {goog.graphics.Element}
+ * @return {Object}
+ */
+thin.core.ModuleShape.prototype.toHash_ = function() {
+  var style = {
+    'display': this.getDisplay()
+  };
+
+  var stroke = this.getStroke();
+  if (stroke) {
+    goog.object.extend(style, {
+      'border-color': stroke.getColor(),
+      'border-width': this.getStrokeWidth(),
+      'border-style': this.getStrokeDashType()
+    });
+  }
+  var fill = this.getFill();
+  if (fill) {
+    goog.object.set(style, 'fill-color', fill.getColor());
+  }
+
+  return {
+    'id': this.getShapeId(),
+    'type': this.getType(),
+    'description': this.getDesc(),
+    // Absolute positions(without translate)
+    'x': this.left_,
+    'y': this.top_,
+    'width': this.width_,
+    'height': this.height_,
+    'style': style
+  };
+};
+
+
+/**
+ * @private
+ * @this {goog.graphics.Element}
+ * @param {Object}
+ */
+thin.core.ModuleShape.prototype.update_ = function(attrs) {
+  goog.object.forEach(attrs, function(value, attr) {
+    switch (attr) {
+      case 'id':
+        // FIXME setShapeId
+        this.setShapeId(value);
+        break;
+      case 'description':
+        this.setDesc(value);
+        break;
+      case 'x':
+        this.setLeft(value);
+        break;
+      case 'y':
+        this.setTop(value);
+        break;
+      case 'width':
+        this.setWidth(value);
+        break;
+      case 'height':
+        this.setHeight(value);
+        break;
+      case 'display':
+        this.setDisplay(value);
+        break;
+      case 'border-color':
+        this.setStrokeColor(value);
+        break;
+      case 'border-width':
+        this.setStrokeWidth(value);
+        break;
+      case 'border-style':
+        this.setStrokeDashFromType(value);
+        break;
+      case 'fill-color':
+        this.setFillColor(value);
+        break;
+      case 'style':
+        this.update(value);
+        break;
+      default:
+        // Do Nothing
+        break;
+      }
+
+  }, this);
 };

--- a/src/app/core/moduleshape.js
+++ b/src/app/core/moduleshape.js
@@ -210,7 +210,7 @@ thin.core.ModuleShape.prototype.setShapeId_ = function(newShapeId, opt_shapeIdMa
   if (!opt_shapeIdManager && this.isAffiliationListShape()) {
     opt_shapeIdManager = this.getAffiliationSectionShape().getManager().getShapeIdManager();
   }
-  
+
   var shapeIdManager = opt_shapeIdManager || this.getLayout().getManager().getShapeIdManager();
   var newPrefix = thin.core.ShapeIdManager.getShapeIdPrefix(newShapeId);
   this.deleteShapeId_(shapeIdManager);
@@ -247,7 +247,7 @@ thin.core.ModuleShape.prototype.setShapeId = function(newShapeId, opt_shapeIdMan
   if (!opt_shapeIdManager && this.isAffiliationListShape()) {
     opt_shapeIdManager = this.getAffiliationSectionShape().getManager().getShapeIdManager();
   }
-  
+
   if (thin.isExactlyEqual(newShapeId, thin.core.ModuleShape.DEFAULT_SHAPEID)) {
     this.deleteShapeId_(opt_shapeIdManager);
   } else {
@@ -412,7 +412,7 @@ thin.core.ModuleShape.prototype.setMouseDownHandlers = function() {
         thin.core.ListShape.CLASSID + goog.object.get(listShapeClassIdTemp, 'FACE');
   var isAffiliationListShape = this.isAffiliationListShape();
   var affiliationSectionName = this.getAffiliationSectionName();
-  
+
   goog.events.listen(this, goog.events.EventType.MOUSEDOWN, function(e) {
     layout.getWorkspace().focusElement(e);
     var singleShapeByGlobal = activeShapeManager.getIfSingle();
@@ -423,7 +423,7 @@ thin.core.ModuleShape.prototype.setMouseDownHandlers = function() {
     var captureProperties = multipleShapesHelper.getCloneProperties();
     var captureActive = listHelper.isActive();
     var captureCtrlKey = e.ctrlKey || e.metaKey;
-    
+
     if (captureActive) {
       var activeShapeManagerByListShape = listHelper.getActiveShape();
       var singleShapeByListShape = activeShapeManagerByListShape.getIfSingle();
@@ -433,10 +433,10 @@ thin.core.ModuleShape.prototype.setMouseDownHandlers = function() {
       var isMultipleByListShape = activeShapeManagerByListShape.isMultiple();
       var captureActiveSectionName = listHelper.getActiveSectionName();
     }
-    
+
     e.stopPropagation();
     e.preventDefault();
-    
+
     layout.getWorkspace().normalVersioning(function(version) {
       version.setChanged(false);
 
@@ -453,9 +453,9 @@ thin.core.ModuleShape.prototype.setMouseDownHandlers = function() {
           listHelper.active(listShape);
           listShape.updateProperties();
           thin.ui.setEnabledForFontUi(false);
-          
+
         } else {
-        
+
           if (captureCtrlKey) {
             this.dragger_.setEnabled(false);
             if (isAffiliationListShape) {
@@ -508,14 +508,14 @@ thin.core.ModuleShape.prototype.setMouseDownHandlers = function() {
                   guide.setEnableAndTargetShape(this);
                   layout.setOutlineForSingle(this);
                   this.updateProperties();
-                  
+
                 } else {
                   if (isSelfMouseDown) {
                     activeShapeManager.clear();
                     layout.updatePropertiesForEmpty();
                     thin.ui.setEnabledForFontUi(false);
                   } else {
-                  
+
                     manager.setActiveShape(this);
                     var shapes = activeShapeManager.get();
                     layout.setOutlineForMultiple(shapes);
@@ -539,7 +539,7 @@ thin.core.ModuleShape.prototype.setMouseDownHandlers = function() {
                 listHelper.inactive();
               }
             }
-            
+
           } else {
             this.dragger_.setEnabled(true);
             if (isAffiliationListShape) {
@@ -563,12 +563,12 @@ thin.core.ModuleShape.prototype.setMouseDownHandlers = function() {
           }
         }
       }, scope);
-      
+
       version.downHandler(function() {
         if (isListShapeFace) {
           activeShapeManager.set(oldShapesByGlobal);
           listHelper.inactive();
-          
+
           if (!captureActive) {
             if (isEmptyByGlobal) {
               layout.updatePropertiesForEmpty();
@@ -592,7 +592,7 @@ thin.core.ModuleShape.prototype.setMouseDownHandlers = function() {
           } else {
             listHelper.active(singleShapeByGlobal);
             listHelper.setActiveSectionName(captureActiveSectionName);
-            
+
             if (isEmptyByListShape) {
               singleShapeByGlobal.updateProperties();
               thin.ui.setEnabledForFontUi(false);
@@ -650,7 +650,7 @@ thin.core.ModuleShape.prototype.setMouseDownHandlers = function() {
               if (isAffiliationListShape) {
                 activeShapeManagerByListShape.set(oldShapesByListShape);
                 listHelper.setActiveSectionName(captureActiveSectionName);
-                
+
                 if (isSelfMouseDown) {
                   singleShapeByListShape.updateToolbarUI();
                   guide.setEnableAndTargetShape(singleShapeByListShape);
@@ -687,7 +687,7 @@ thin.core.ModuleShape.prototype.setMouseDownHandlers = function() {
                 activeShapeManager.set(oldShapesByGlobal);
                 listHelper.active(singleShapeByGlobal);
                 listHelper.setActiveSectionName(captureActiveSectionName);
-                
+
                 if (isEmptyByListShape) {
                   guide.setDisable();
                   singleShapeByGlobal.updateProperties();
@@ -766,7 +766,7 @@ thin.core.ModuleShape.prototype.setMouseDownHandlers = function() {
                 activeShapeManager.set(oldShapesByGlobal);
                 listHelper.active(singleShapeByGlobal);
                 listHelper.setActiveSectionName(captureActiveSectionName);
-                
+
                 if (isEmptyByListShape) {
                   singleShapeByGlobal.updateProperties();
                   thin.ui.setEnabledForFontUi(false);
@@ -808,14 +808,14 @@ thin.core.ModuleShape.prototype.setupDragHandlers = function() {
   var body = goog.dom.getDocument().body;
   var dragLayer = helpers.getDragLayer();
   var eventType = goog.fx.Dragger.EventType;
-  
+
   var dragger = new thin.core.SvgDragger(this.getTargetOutline(), this);
   this.dragger_ = dragger;
-  
+
   goog.events.listen(dragger, thin.core.AbstractDragger.EventType.BEFORESTART, function(e) {
     this.getTargetOutline().setBounds(this.getBounds());
   }, false, this);
-  
+
   goog.events.listen(dragger, eventType.START, function(e) {
     dragger.setAdsorptionX(helpers.getAdsorptionX());
     dragger.setAdsorptionY(helpers.getAdsorptionY());
@@ -826,7 +826,7 @@ thin.core.ModuleShape.prototype.setupDragHandlers = function() {
     layout.setElementCursor(dragLayer.getElement(), cursorMove);
     dragLayer.setVisibled(true);
   }, false, this);
-  
+
   goog.events.listen(dragger, eventType.BEFOREDRAG, function(e) {
     var outline = this.getTargetOutline();
     if (!outline.isEnable()) {
@@ -834,7 +834,7 @@ thin.core.ModuleShape.prototype.setupDragHandlers = function() {
     }
   }, false, this);
   goog.events.listen(dragger, eventType.END, function(e) {
-  
+
     var cursorTypeDefault = thin.core.Cursor.Type.DEFAULT;
     var cursorDefault = new thin.core.Cursor(cursorTypeDefault);
     goog.style.setStyle(body, 'cursor', cursorTypeDefault);
@@ -845,7 +845,7 @@ thin.core.ModuleShape.prototype.setupDragHandlers = function() {
     var outlineBounds = outline.getBounds();
     var shapeBounds = this.getBounds();
     var enabled = outline.isEnable();
-    
+
     layout.getWorkspace().normalVersioning(function(version) {
       if (goog.math.Rect.equals(shapeBounds, outlineBounds)) {
         version.setChanged(false);
@@ -860,7 +860,7 @@ thin.core.ModuleShape.prototype.setupDragHandlers = function() {
           outline.disable();
         }
       }, scope);
-      
+
       version.downHandler(function() {
         if (enabled) {
           outline.setTargetShape(this);
@@ -880,22 +880,22 @@ thin.core.ModuleShape.prototype.setupDragHandlers = function() {
  * @param {e} thin.ui.PropertyPane.PropertyEvent
  */
 thin.core.ModuleShape.prototype.setLeftForPropertyUpdate = function(e) {
-  
+
   var scope = this;
   var layout = this.getLayout();
   var guide = layout.getHelpers().getGuideHelper();
   var proppane = thin.ui.getComponent('proppane');
   var captureLeft = this.getLeft();
   var allowLeft = this.getAllowLeft(Number(e.target.getValue()));
-  
+
   layout.getWorkspace().normalVersioning(function(version) {
-  
+
     version.upHandler(function() {
       this.setLeft(allowLeft);
       guide.adjustToTargetShapeBounds();
       proppane.getPropertyControl('left').setValue(allowLeft);
     }, scope);
-    
+
     version.downHandler(function() {
       this.setLeft(captureLeft);
       guide.adjustToTargetShapeBounds();
@@ -916,15 +916,15 @@ thin.core.ModuleShape.prototype.setTopForPropertyUpdate = function(e) {
   var proppane = thin.ui.getComponent('proppane');
   var captureTop = this.getTop();
   var allowTop = this.getAllowTop(Number(e.target.getValue()));
-  
+
   layout.getWorkspace().normalVersioning(function(version) {
-  
+
     version.upHandler(function() {
       this.setTop(allowTop);
       guide.adjustToTargetShapeBounds();
       proppane.getPropertyControl('top').setValue(allowTop);
     }, scope);
-    
+
     version.downHandler(function() {
       this.setTop(captureTop);
       guide.adjustToTargetShapeBounds();
@@ -948,14 +948,14 @@ thin.core.ModuleShape.prototype.setWidthForPropertyUpdate = function(e) {
   var allowWidth = Number(e.target.getValue());
 
   layout.getWorkspace().normalVersioning(function(version) {
-  
+
     version.upHandler(function() {
       this.setWidth(allowWidth);
       this.setLeft(captureLeft);
       guide.adjustToTargetShapeBounds();
       proppane.getPropertyControl('width').setValue(allowWidth);
     }, scope);
-    
+
     version.downHandler(function() {
       this.setWidth(captureWidth);
       this.setLeft(captureLeft);
@@ -978,16 +978,16 @@ thin.core.ModuleShape.prototype.setHeightForPropertyUpdate = function(e) {
   var captureHeight = this.getHeight();
   var captureTop = this.getTop();
   var allowHeight = Number(e.target.getValue());
-  
+
   layout.getWorkspace().normalVersioning(function(version) {
-  
+
     version.upHandler(function() {
       this.setHeight(allowHeight);
       this.setTop(captureTop);
       guide.adjustToTargetShapeBounds();
       proppane.getPropertyControl('height').setValue(allowHeight);
     }, scope);
-    
+
     version.downHandler(function() {
       this.setHeight(captureHeight);
       this.setTop(captureTop);
@@ -1018,12 +1018,12 @@ thin.core.ModuleShape.prototype.setFillForPropertyUpdate = function(e) {
   }
 
   this.getLayout().getWorkspace().normalVersioning(function(version) {
-  
+
     version.upHandler(function() {
       this.setFill(fill);
       proppane.getPropertyControl('fill').setValue(fillColor);
     }, scope);
-    
+
     version.downHandler(function() {
       this.setFill(captureFill);
       proppane.getPropertyControl('fill').setValue(captureFillColor);
@@ -1045,7 +1045,7 @@ thin.core.ModuleShape.prototype.setStrokeForPropertyUpdate = function(e) {
   var captureStrokeColor = captureStroke.getColor();
   //  choose none color returned null.
   var strokeColor = /** @type {string} */(thin.getValIfNotDef(e.target.getValue(), proppaneBlank));
-  var stroke = new goog.graphics.Stroke(captureStroke.getWidth(), 
+  var stroke = new goog.graphics.Stroke(captureStroke.getWidth(),
                      thin.isExactlyEqual(strokeColor, proppaneBlank) ? strokeNone : strokeColor);
 
   if (thin.isExactlyEqual(captureStrokeColor, strokeNone)) {
@@ -1053,12 +1053,12 @@ thin.core.ModuleShape.prototype.setStrokeForPropertyUpdate = function(e) {
   }
 
   this.getLayout().getWorkspace().normalVersioning(function(version) {
-  
+
     version.upHandler(function() {
       this.setStroke(stroke);
       proppane.getPropertyControl('stroke').setValue(strokeColor);
     }, scope);
-    
+
     version.downHandler(function() {
       this.setStroke(captureStroke);
       proppane.getPropertyControl('stroke').setValue(captureStrokeColor);
@@ -1078,17 +1078,17 @@ thin.core.ModuleShape.prototype.setStrokeWidthForPropertyUpdate = function(e) {
   var propStrokeWidth = thin.core.ModuleElement.DEFAULT_STROKEWIDTH_OF_PROPPANE;
   var strokeWidth = Number(e.target.getValue());
   var captureStrokeWidth = this.getStroke().getWidth();
-  var showStrokeWidth = thin.isExactlyEqual(strokeWidth, propStrokeWidth) ? 
+  var showStrokeWidth = thin.isExactlyEqual(strokeWidth, propStrokeWidth) ?
                             proppaneBlank : strokeWidth;
-  var showCaptureStrokeWidth = thin.isExactlyEqual(captureStrokeWidth, propStrokeWidth) ? 
+  var showCaptureStrokeWidth = thin.isExactlyEqual(captureStrokeWidth, propStrokeWidth) ?
                                    proppaneBlank : captureStrokeWidth;
-  
+
   this.getLayout().getWorkspace().normalVersioning(function(version) {
     version.upHandler(function() {
       this.setStrokeWidth(strokeWidth);
       proppane.getPropertyControl('stroke-width').setInternalValue(showStrokeWidth);
     }, scope);
-    
+
     version.downHandler(function() {
       this.setStrokeWidth(captureStrokeWidth);
       proppane.getPropertyControl('stroke-width').setInternalValue(showCaptureStrokeWidth);
@@ -1106,14 +1106,14 @@ thin.core.ModuleShape.prototype.setStrokeDashTypeForPropertyUpdate = function(e)
   var proppane = thin.ui.getComponent('proppane');
   var strokeType = e.target.getValue();
   var captureStrokeType = this.getStrokeDashType();
-  
+
   this.getLayout().getWorkspace().normalVersioning(function(version) {
-  
+
     version.upHandler(function() {
       this.setStrokeDashFromType(strokeType);
       proppane.getPropertyControl('stroke-dash-type').setValue(strokeType);
     }, scope);
-    
+
     version.downHandler(function() {
       this.setStrokeDashFromType(captureStrokeType);
       proppane.getPropertyControl('stroke-dash-type').setValue(captureStrokeType);
@@ -1131,14 +1131,14 @@ thin.core.ModuleShape.prototype.setShapeIdForPropertyUpdate = function(e) {
   var proppane = thin.ui.getComponent('proppane');
   var shapeId = e.target.getValue();
   var captureShapeId = this.getShapeId();
-  
+
   this.getLayout().getWorkspace().normalVersioning(function(version) {
 
     version.upHandler(function() {
       this.setShapeId(shapeId);
       proppane.getPropertyControl('shape-id').setValue(shapeId);
     }, scope);
-    
+
     version.downHandler(function() {
       this.setShapeId(captureShapeId);
       proppane.getPropertyControl('shape-id').setValue(captureShapeId);
@@ -1156,13 +1156,13 @@ thin.core.ModuleShape.prototype.setDescPropertyUpdate = function(e) {
   var proppane = thin.ui.getComponent('proppane');
   var desc = e.target.getValue();
   var captureDesc = this.getDesc();
-  
+
   this.getLayout().getWorkspace().normalVersioning(function(version) {
     version.upHandler(function() {
       this.setDesc(desc);
       proppane.getPropertyControl('desc').setValue(desc);
     }, scope);
-    
+
     version.downHandler(function() {
       this.setDesc(captureDesc);
       proppane.getPropertyControl('desc').setValue(captureDesc);
@@ -1180,14 +1180,14 @@ thin.core.ModuleShape.prototype.setDisplayForPropertyUpdate = function(e) {
   var proppane = thin.ui.getComponent('proppane');
   var display = e.target.isChecked();
   var captureDisplay = this.getDisplay();
-  
+
   this.getLayout().getWorkspace().normalVersioning(function(version) {
-  
+
     version.upHandler(function() {
       this.setDisplay(display);
       proppane.getPropertyControl('display').setChecked(display);
     }, scope);
-    
+
     version.downHandler(function() {
       this.setDisplay(captureDisplay);
       proppane.getPropertyControl('display').setChecked(captureDisplay);
@@ -1210,7 +1210,7 @@ thin.core.ModuleShape.prototype.setSectionEnabled = function(
   var listShape = listHelper.getTarget();
   var captureBounds = listShape.getBounds();
   var captureActiveSectionName = listHelper.getActiveSectionName();
-  
+
   layout.getWorkspace().normalVersioning(function(version) {
     version.upHandler(function() {
       listShape.setEnabledForSection(enabled, sectionName);
@@ -1218,7 +1218,7 @@ thin.core.ModuleShape.prototype.setSectionEnabled = function(
       listHelper.initActiveSectionName();
       listShape.updateProperties();
     }, scope);
-    
+
     version.downHandler(function() {
       listShape.setBounds(captureBounds);
       listShape.setEnabledForSection(!enabled, sectionName);
@@ -1270,9 +1270,7 @@ thin.core.ModuleShape.prototype.getType = function() {
  * @return {Object}
  */
 thin.core.ModuleShape.prototype.toHash_ = function() {
-  var style = {
-    'display': this.getDisplay()
-  };
+  var style = {};
 
   var stroke = this.getStroke();
   if (stroke) {
@@ -1290,6 +1288,7 @@ thin.core.ModuleShape.prototype.toHash_ = function() {
   return {
     'id': this.getShapeId(),
     'type': this.getType(),
+    'display': this.getDisplay(),
     'description': this.getDesc(),
     // Absolute positions(without translate)
     'x': this.left_,
@@ -1310,17 +1309,16 @@ thin.core.ModuleShape.prototype.update_ = function(attrs) {
   goog.object.forEach(attrs, function(value, attr) {
     switch (attr) {
       case 'id':
-        // FIXME setShapeId
         this.setShapeId(value);
         break;
       case 'description':
         this.setDesc(value);
         break;
       case 'x':
-        this.setLeft(value);
+        this.setLeft(value + this.getParentTransLateX());
         break;
       case 'y':
-        this.setTop(value);
+        this.setTop(value + this.getParentTransLateY());
         break;
       case 'width':
         this.setWidth(value);

--- a/src/app/core/moduleshape.js
+++ b/src/app/core/moduleshape.js
@@ -1269,7 +1269,7 @@ thin.core.ModuleShape.prototype.getType = function() {
  * @this {goog.graphics.Element}
  * @return {Object}
  */
-thin.core.ModuleShape.prototype.toHash_ = function() {
+thin.core.ModuleShape.prototype.asJSON_ = function() {
   var style = {};
 
   var stroke = this.getStroke();

--- a/src/app/core/pagenumbershape.js
+++ b/src/app/core/pagenumbershape.js
@@ -144,41 +144,6 @@ thin.core.PageNumberShape.prototype.updateToolbarUI = function() {
 
 
 /**
- * @param {Element} element
- * @param {thin.core.Layout} layout
- * @param {thin.core.ShapeIdManager=} opt_shapeIdManager
- * @return {thin.core.PageNumberShape}
- */
-thin.core.PageNumberShape.createFromElement = function(element, layout, opt_shapeIdManager) {
-  element.removeAttribute('clip-path');
-  var shape = new thin.core.PageNumberShape(element, layout);
-
-  shape.setShapeId(layout.getElementAttribute(element, 'x-id'), opt_shapeIdManager);
-  shape.setFill(new goog.graphics.SolidFill(layout.getElementAttribute(element, 'fill')));
-  shape.setFontSize(Number(layout.getElementAttribute(element, 'font-size')));
-  shape.setFontFamily(layout.getElementAttribute(element, 'font-family'));
-
-  var decoration = layout.getElementAttribute(element, 'text-decoration');
-  var kerning = layout.getElementAttribute(element, 'kerning');
-
-  if (thin.isExactlyEqual(kerning, thin.core.TextStyle.DEFAULT_ELEMENT_KERNING)) {
-    kerning = thin.core.TextStyle.DEFAULT_KERNING;
-  }
-  shape.setKerning(/** @type {string} */ (kerning));
-  shape.setFontUnderline(/underline/.test(decoration));
-  shape.setFontLinethrough(/line-through/.test(decoration));
-  shape.setFontItalic(layout.getElementAttribute(element, 'font-style') == 'italic');
-  shape.setFontBold(layout.getElementAttribute(element, 'font-weight') == 'bold');
-  shape.setTextAnchor(layout.getElementAttribute(element, 'text-anchor'));
-  shape.setDisplay(layout.getElementAttribute(element, 'x-display') == 'true');
-  shape.setDesc(layout.getElementAttribute(element, 'x-desc'));
-  shape.initIdentifier();
-
-  return shape;
-};
-
-
-/**
  * @param {Element=} opt_element
  * @return {thin.core.Box}
  * @private
@@ -894,4 +859,54 @@ thin.core.PageNumberShape.Label_.prototype.repositionY = function() {
 thin.core.PageNumberShape.Label_.prototype.disposeInternal = function() {
   goog.base(this, 'disposeInternal');
   delete this.parent_;
+};
+
+
+/**
+ * @return {string}
+ */
+thin.core.PageNumberShape.prototype.getType = function() {
+  return 'page-number';
+};
+
+
+/**
+ * @return {Object}
+ */
+thin.core.PageNumberShape.prototype.toHash = function() {
+  var hash = goog.base(this, 'toHash');
+
+  goog.object.extend(hash, {
+    'format': this.getFormat(),
+    'target': this.getTargetId() || 'report'
+  });
+  goog.object.set(hash['style'], 'overflow', this.getOverflowType());
+
+  return hash;
+};
+
+
+/**
+ * @param {Object} attrs
+ */
+thin.core.PageNumberShape.prototype.update = function(attrs) {
+  goog.base(this, 'update', attrs);
+
+  goog.object.forEach(attrs, function(value, attr) {
+    switch (attr) {
+      case 'format':
+        this.setFormat(value);
+        break;
+      case 'target':
+        // FIXME setShapeId
+        // this.setTargetId(value);
+        break;
+      case 'overflow':
+        this.setOverflowType(value);
+        break;
+      default:
+        // Do Nothing
+        break;
+      }
+  }, this);
 };

--- a/src/app/core/pagenumbershape.js
+++ b/src/app/core/pagenumbershape.js
@@ -843,24 +843,24 @@ thin.core.PageNumberShape.prototype.getType = function() {
 /**
  * @return {Object}
  */
-thin.core.PageNumberShape.prototype.toHash = function() {
-  var hash = goog.base(this, 'toHash');
+thin.core.PageNumberShape.prototype.asJSON = function() {
+  var object = goog.base(this, 'asJSON');
 
-  goog.object.extend(hash, {
+  goog.object.extend(object, {
     'format': this.getFormat(),
     'target': this.getTargetId()
   });
 
-  var style = goog.object.clone(hash['style']);
+  var style = goog.object.clone(object['style']);
   goog.object.remove(style, 'word-wrap');
   goog.object.remove(style, 'line-height');
   goog.object.remove(style, 'line-height-ratio');
   goog.object.remove(style, 'vertical-align');
   goog.object.set(style, 'overflow', this.getOverflowType());
 
-  goog.object.set(hash, 'style', style);
+  goog.object.set(object, 'style', style);
 
-  return hash;
+  return object;
 };
 
 

--- a/src/app/core/pagenumbershape.js
+++ b/src/app/core/pagenumbershape.js
@@ -113,13 +113,6 @@ thin.core.PageNumberShape.prototype.base_;
 
 
 /**
- * @type {goog.graphics.Element}
- * @private
- */
-thin.core.PageNumberShape.prototype.targetShape_;
-
-
-/**
  * @return {string}
  */
 thin.core.PageNumberShape.prototype.getClassId = function() {
@@ -293,9 +286,6 @@ thin.core.PageNumberShape.prototype.setTargetId = function(targetId) {
   layout.setElementAttributes(this.getElement(), {
     'x-target': targetId
   });
-  if (!goog.string.isEmpty(targetId)) {
-    this.setTargetShape_(layout.getShapeForShapeId(targetId));
-  }
 };
 
 
@@ -308,30 +298,10 @@ thin.core.PageNumberShape.prototype.getTargetId = function() {
 };
 
 
-/**
- * @param {goog.graphics.Element} targetShape
- * @private
- */
-thin.core.PageNumberShape.prototype.setTargetShape_ = function(targetShape) {
-  this.targetShape_ = targetShape;
-  this.targetShape_.setPageNumberReference(this);
-};
-
-
-/**
- * @return {goog.graphics.Element}
- */
-thin.core.PageNumberShape.prototype.getTargetShape = function() {
-  return this.targetShape_;
-};
-
-
-thin.core.PageNumberShape.prototype.removeTargetShape = function() {
-  if (this.targetShape_) {
-    this.targetShape_.removePageNumberReference(this);
+thin.core.PageNumberShape.prototype.removeTargetShapeId = function() {
+  if (!goog.string.isEmpty(this.getTargetId())) {
     this.setTargetId('');
   }
-  delete this.targetShape_;
 };
 
 
@@ -880,7 +850,15 @@ thin.core.PageNumberShape.prototype.toHash = function() {
     'format': this.getFormat(),
     'target': this.getTargetId() || 'report'
   });
-  goog.object.set(hash['style'], 'overflow', this.getOverflowType());
+
+  var style = goog.object.clone(hash['style']);
+  goog.object.remove(style, 'word-wrap');
+  goog.object.remove(style, 'line-height');
+  goog.object.remove(style, 'line-height-ratio');
+  goog.object.remove(style, 'vertical-align');
+  goog.object.set(style, 'overflow', this.getOverflowType());
+
+  goog.object.set(hash, 'style', style);
 
   return hash;
 };
@@ -892,14 +870,18 @@ thin.core.PageNumberShape.prototype.toHash = function() {
 thin.core.PageNumberShape.prototype.update = function(attrs) {
   goog.base(this, 'update', attrs);
 
+  this.label_.repositionX();
+  this.label_.repositionY();
+
   goog.object.forEach(attrs, function(value, attr) {
     switch (attr) {
       case 'format':
         this.setFormat(value);
         break;
       case 'target':
-        // FIXME setShapeId
-        // this.setTargetId(value);
+        if (!thin.isExactlyEqual('report', value)){
+          this.setTargetId(value);
+        }
         break;
       case 'overflow':
         this.setOverflowType(value);

--- a/src/app/core/pagenumbershape.js
+++ b/src/app/core/pagenumbershape.js
@@ -848,7 +848,7 @@ thin.core.PageNumberShape.prototype.toHash = function() {
 
   goog.object.extend(hash, {
     'format': this.getFormat(),
-    'target': this.getTargetId() || 'report'
+    'target': this.getTargetId()
   });
 
   var style = goog.object.clone(hash['style']);
@@ -879,9 +879,7 @@ thin.core.PageNumberShape.prototype.update = function(attrs) {
         this.setFormat(value);
         break;
       case 'target':
-        if (!thin.isExactlyEqual('report', value)){
-          this.setTargetId(value);
-        }
+        this.setTargetId(value);
         break;
       case 'overflow':
         this.setOverflowType(value);

--- a/src/app/core/rectshape.js
+++ b/src/app/core/rectshape.js
@@ -368,14 +368,14 @@ thin.core.RectShape.prototype.disposeInternal = function() {
 /**
  * @return {Object}
  */
-thin.core.RectShape.prototype.toHash = function() {
-  var hash = this.toHash_();
+thin.core.RectShape.prototype.asJSON = function() {
+  var object = this.asJSON_();
 
-  goog.object.extend(hash, {
+  goog.object.extend(object, {
     'border-radius': this.getRounded()
   });
 
-  return hash;
+  return object;
 };
 
 
@@ -385,13 +385,7 @@ thin.core.RectShape.prototype.toHash = function() {
 thin.core.RectShape.prototype.update = function(attrs) {
   this.update_(attrs);
 
-  goog.object.forEach(attrs, function(value, attr) {
-    switch (attr) {
-      case 'border-radius':
-        this.setRounded(value);
-        break;
-      default:
-        break;
-      }
-  }, this);
+  if (goog.object.containsKey(attrs, 'border-radius')) {
+    this.setRounded(attrs['border-radius']);
+  }
 };

--- a/src/app/core/rectshape.js
+++ b/src/app/core/rectshape.js
@@ -106,10 +106,10 @@ thin.core.RectShape.prototype.getCloneCreator = function() {
    * @return {thin.core.RectShape}
    */
   return function(layout, opt_isAdaptDeltaForList, opt_renderTo, opt_basisCoordinate) {
-    
+
     var shape = layout.createRectShape();
     layout.appendChild(shape, opt_renderTo);
-    
+
     var pasteCoordinate = layout.calculatePasteCoordinate(isAffiliationListShape,
           deltaCoordinateForList, deltaCoordinateForGuide, sourceCoordinate,
           opt_isAdaptDeltaForList, opt_renderTo, opt_basisCoordinate);
@@ -131,81 +131,81 @@ thin.core.RectShape.prototype.getCloneCreator = function() {
  * @private
  */
 thin.core.RectShape.prototype.createPropertyComponent_ = function() {
-  
+
   var scope = this;
   var layout = this.getLayout();
   var propEventType = thin.ui.PropertyPane.Property.EventType;
   var proppane = thin.ui.getComponent('proppane');
-  
+
   var baseGroup = proppane.addGroup(thin.t('property_group_basis'));
-  
-  
+
+
   var leftInputProperty = new thin.ui.PropertyPane.NumberInputProperty(thin.t('field_left_position'));
   var leftInput = leftInputProperty.getValueControl();
   leftInput.getNumberValidator().setAllowDecimal(true, 1);
-  
+
   leftInputProperty.addEventListener(propEventType.CHANGE,
       this.setLeftForPropertyUpdate, false, this);
-  
+
   proppane.addProperty(leftInputProperty, baseGroup, 'left');
 
 
   var topInputProperty = new thin.ui.PropertyPane.NumberInputProperty(thin.t('field_top_position'));
   var topInput = topInputProperty.getValueControl();
   topInput.getNumberValidator().setAllowDecimal(true, 1);
-  
+
   topInputProperty.addEventListener(propEventType.CHANGE,
       this.setTopForPropertyUpdate, false, this);
-  
+
   proppane.addProperty(topInputProperty, baseGroup, 'top');
-  
-  
+
+
   var widthInputProperty = new thin.ui.PropertyPane.NumberInputProperty(thin.t('field_width'));
   var widthInput = widthInputProperty.getValueControl();
   widthInput.getNumberValidator().setAllowDecimal(true, 1);
-  
+
   widthInputProperty.addEventListener(propEventType.CHANGE,
       this.setWidthForPropertyUpdate, false, this);
-  
+
   proppane.addProperty(widthInputProperty, baseGroup, 'width');
-  
-  
+
+
   var heightInputProperty = new thin.ui.PropertyPane.NumberInputProperty(thin.t('field_height'));
   var heightInput = heightInputProperty.getValueControl();
   heightInput.getNumberValidator().setAllowDecimal(true, 1);
-  
+
   heightInputProperty.addEventListener(propEventType.CHANGE,
       this.setHeightForPropertyUpdate, false, this);
-  
+
   proppane.addProperty(heightInputProperty, baseGroup, 'height');
-  
-  
+
+
   var displayCheckProperty = new thin.ui.PropertyPane.CheckboxProperty(thin.t('field_display'));
   displayCheckProperty.addEventListener(propEventType.CHANGE,
       this.setDisplayForPropertyUpdate, false, this);
-  
+
   proppane.addProperty(displayCheckProperty, baseGroup, 'display');
 
-  
+
   var shapeGroup = proppane.addGroup(thin.t('property_group_shape'));
-  
-  
+
+
   var fillInputProperty = new thin.ui.PropertyPane.ColorProperty(thin.t('field_fill_color'));
   fillInputProperty.getValueControl().getInput().setLabel('none');
   fillInputProperty.addEventListener(propEventType.CHANGE,
       this.setFillForPropertyUpdate, false, this);
-  
+
   proppane.addProperty(fillInputProperty , shapeGroup, 'fill');
-  
-  
+
+
   var strokeInputProperty = new thin.ui.PropertyPane.ColorProperty(thin.t('field_stroke_color'));
   strokeInputProperty.getValueControl().getInput().setLabel('none');
   strokeInputProperty.addEventListener(propEventType.CHANGE,
       this.setStrokeForPropertyUpdate, false, this);
-  
+
   proppane.addProperty(strokeInputProperty , shapeGroup, 'stroke');
-  
-  
+
+
   var strokeWidthCombProperty = new thin.ui.PropertyPane.ComboBoxProperty(thin.t('field_stroke_width'));
   var strokeWidthComb = strokeWidthCombProperty.getValueControl();
   var strokeWidthInput = strokeWidthComb.getInput();
@@ -224,10 +224,10 @@ thin.core.RectShape.prototype.createPropertyComponent_ = function() {
   });
   strokeWidthCombProperty.addEventListener(propEventType.CHANGE,
       this.setStrokeWidthForPropertyUpdate, false, this);
-  
+
   proppane.addProperty(strokeWidthCombProperty , shapeGroup, 'stroke-width');
-  
-  
+
+
   var strokeType = thin.core.ModuleElement.StrokeType;
   var strokeDashSelectProperty = new thin.ui.PropertyPane.SelectProperty(thin.t('field_stroke_type'));
   var strokeDashSelect = strokeDashSelectProperty.getValueControl();
@@ -239,10 +239,10 @@ thin.core.RectShape.prototype.createPropertyComponent_ = function() {
       new thin.ui.Option(thin.core.ModuleElement.getStrokeName(strokeType.DASHED), strokeType.DASHED));
   strokeDashSelect.addItem(
       new thin.ui.Option(thin.core.ModuleElement.getStrokeName(strokeType.DOTTED), strokeType.DOTTED));
-  
+
   strokeDashSelectProperty.addEventListener(propEventType.CHANGE,
       this.setStrokeDashTypeForPropertyUpdate, false, this);
-  
+
   proppane.addProperty(strokeDashSelectProperty , shapeGroup, 'stroke-dash-type');
 
 
@@ -252,36 +252,36 @@ thin.core.RectShape.prototype.createPropertyComponent_ = function() {
       function(e) {
         var radius = Number(e.target.getValue());
         var captureRadius = scope.getRounded();
-        
+
         layout.getWorkspace().normalVersioning(function(version) {
-        
+
           version.upHandler(function() {
             this.setRounded(radius);
             proppane.getPropertyControl('radius').setValue(radius);
           }, scope);
-          
+
           version.downHandler(function() {
             this.setRounded(captureRadius);
             proppane.getPropertyControl('radius').setValue(captureRadius);
           }, scope);
         });
       }, false, this);
-  
+
   proppane.addProperty(radiusInputProperty, shapeGroup, 'radius');
 
 
   var cooperationGroup = proppane.addGroup(thin.t('property_group_association'));
-  
+
   var idInputProperty = new thin.ui.PropertyPane.IdInputProperty(this, 'ID');
   idInputProperty.addEventListener(propEventType.CHANGE,
       this.setShapeIdForPropertyUpdate, false, this);
-  
+
   proppane.addProperty(idInputProperty, cooperationGroup, 'shape-id');
-  
+
   var descProperty = new thin.ui.PropertyPane.InputProperty(thin.t('field_description'));
   descProperty.addEventListener(propEventType.CHANGE,
       this.setDescPropertyUpdate, false, this);
-  
+
   proppane.addProperty(descProperty, cooperationGroup, 'desc');
 };
 
@@ -315,17 +315,17 @@ thin.core.RectShape.prototype.updateProperties = function() {
     proppane.setTarget(this);
     this.createPropertyComponent_();
   }
-  
+
   var properties = this.getProperties();
   var proppaneBlank = thin.core.ModuleShape.PROPPANE_SHOW_BLANK;
   var noneColor = thin.core.ModuleShape.NONE;
-  
+
   proppane.getPropertyControl('left').setValue(properties['left']);
   proppane.getPropertyControl('top').setValue(properties['top']);
   proppane.getPropertyControl('width').setValue(properties['width']);
   proppane.getPropertyControl('height').setValue(properties['height']);
   proppane.getPropertyControl('display').setChecked(properties['display']);
-  
+
   var fill = properties['fill'];
   if (thin.isExactlyEqual(fill, noneColor)) {
     fill = proppaneBlank
@@ -341,10 +341,10 @@ thin.core.RectShape.prototype.updateProperties = function() {
     strokeWidth = proppaneBlank;
   }
   proppane.getPropertyControl('stroke-width').setInternalValue(strokeWidth);
-  
+
   proppane.getPropertyControl('stroke-dash-type').setValue(properties['stroke-dash-type']);
   proppane.getPropertyControl('radius').setValue(properties['radius']);
-  
+
   proppane.getPropertyControl('shape-id').setValue(properties['shape-id']);
   proppane.getPropertyControl('desc').setValue(properties['desc']);
 };
@@ -372,8 +372,7 @@ thin.core.RectShape.prototype.toHash = function() {
   var hash = this.toHash_();
 
   goog.object.extend(hash, {
-    'rx': this.getRounded(),
-    'ry': this.getRounded()
+    'border-radius': this.getRounded()
   });
 
   return hash;
@@ -388,10 +387,7 @@ thin.core.RectShape.prototype.update = function(attrs) {
 
   goog.object.forEach(attrs, function(value, attr) {
     switch (attr) {
-      case 'rx':
-        this.setRounded(value);
-        break;
-      case 'ry':
+      case 'border-radius':
         this.setRounded(value);
         break;
       default:

--- a/src/app/core/rectshape.js
+++ b/src/app/core/rectshape.js
@@ -64,29 +64,6 @@ thin.core.RectShape.prototype.getClassId = function() {
 };
 
 
-/**
- * @param {Element} element
- * @param {thin.core.Layout} layout
- * @param {thin.core.ShapeIdManager=} opt_shapeIdManager
- * @return {thin.core.RectShape}
- */
-thin.core.RectShape.createFromElement = function(element, layout, opt_shapeIdManager) {
-  var shape = new thin.core.RectShape(element, layout,
-                    new goog.graphics.Stroke(
-                       Number(layout.getElementAttribute(element, 'stroke-width')), 
-                       layout.getElementAttribute(element, 'stroke')),
-                    new goog.graphics.SolidFill(layout.getElementAttribute(element, 'fill')));
-  
-  shape.setShapeId(layout.getElementAttribute(element, 'x-id'), opt_shapeIdManager);
-  shape.setDisplay(layout.getElementAttribute(element, 'x-display') == 'true');
-  shape.setDesc(layout.getElementAttribute(element, 'x-desc'));
-  shape.setStrokeDashFromType(layout.getElementAttribute(element, 'x-stroke-type'));
-  shape.setRounded(Number(layout.getElementAttribute(element, 'rx')));
-  shape.initIdentifier();
-  return shape;
-};
-
-
 thin.core.RectShape.prototype.setDefaultOutline = function() {
   this.setTargetOutline(this.getLayout().getHelpers().getRectOutline());
 };
@@ -385,4 +362,40 @@ thin.core.RectShape.prototype.setInitShapeProperties = function(properties) {
 thin.core.RectShape.prototype.disposeInternal = function() {
   thin.core.RectShape.superClass_.disposeInternal.call(this);
   this.disposeInternalForShape();
+};
+
+
+/**
+ * @return {Object}
+ */
+thin.core.RectShape.prototype.toHash = function() {
+  var hash = this.toHash_();
+
+  goog.object.extend(hash, {
+    'rx': this.getRounded(),
+    'ry': this.getRounded()
+  });
+
+  return hash;
+};
+
+
+/**
+ * @param {Object} attrs
+ */
+thin.core.RectShape.prototype.update = function(attrs) {
+  this.update_(attrs);
+
+  goog.object.forEach(attrs, function(value, attr) {
+    switch (attr) {
+      case 'rx':
+        this.setRounded(value);
+        break;
+      case 'ry':
+        this.setRounded(value);
+        break;
+      default:
+        break;
+      }
+  }, this);
 };

--- a/src/app/core/shapestructure.js
+++ b/src/app/core/shapestructure.js
@@ -27,7 +27,7 @@ thin.core.ShapeStructure.getTransLateCoordinate = function(transformElement) {
   var affineTransform = transformElement.getAttribute('transform');
   var x = 0;
   var y = 0;
-  
+
   if(goog.isDefAndNotNull(affineTransform)) {
     var splitTransLate = affineTransform.match(/[\-\d\,\.]+/)[0].split(',');
     if(splitTransLate.length == 1) {
@@ -65,13 +65,14 @@ thin.core.ShapeStructure.getEnabledOfSection = function(element, parentElement) 
 
 
 /**
+ * @deprecated
  * @param {Element} element
  * @param {thin.core.Layout} layout
  * @param {thin.core.ShapeIdManager=} opt_shapeIdManager
  * @return {thin.core.EllipseShape}
  */
 thin.core.ShapeStructure.createEllipseShapeFromElement = function(element, layout, opt_shapeIdManager) {
-  var shape = new thin.core.EllipseShape(element, layout, 
+  var shape = new thin.core.EllipseShape(element, layout,
                 new goog.graphics.Stroke(
                       Number(layout.getElementAttribute(element, 'stroke-width')),
                       layout.getElementAttribute(element, 'stroke')),
@@ -86,6 +87,7 @@ thin.core.ShapeStructure.createEllipseShapeFromElement = function(element, layou
 
 
 /**
+ * @deprecated
  * @param {Element} element
  * @param {thin.core.Layout} layout
  * @param {thin.core.ShapeIdManager=} opt_shapeIdManager
@@ -106,6 +108,7 @@ thin.core.ShapeStructure.createImageblockShapeFromElement = function(element, la
 
 
 /**
+ * @deprecated
  * @param {Element} element
  * @return {thin.core.ImageFile}
  */
@@ -118,6 +121,7 @@ thin.core.ShapeStructure.createImageFileFromElement = function(element) {
 
 
 /**
+ * @deprecated
  * @param {Element} element
  * @param {thin.core.Layout} layout
  * @param {thin.core.ShapeIdManager=} opt_shapeIdManager
@@ -136,6 +140,7 @@ thin.core.ShapeStructure.createImageShapeFromElement = function(element, layout,
 
 
 /**
+ * @deprecated
  * @param {Element} element
  * @param {thin.core.Layout} layout
  * @param {thin.core.ShapeIdManager=} opt_shapeIdManager
@@ -143,11 +148,11 @@ thin.core.ShapeStructure.createImageShapeFromElement = function(element, layout,
  */
 thin.core.ShapeStructure.createLineShapeFromElement = function(element, layout, opt_shapeIdManager) {
 
-  var shape = new thin.core.LineShape(element, layout, 
+  var shape = new thin.core.LineShape(element, layout,
                   new goog.graphics.Stroke(
                       Number(layout.getElementAttribute(element, 'stroke-width')),
                       layout.getElementAttribute(element, 'stroke')));
-  
+
   shape.setShapeId(layout.getElementAttribute(element, 'x-id'), opt_shapeIdManager);
   shape.setDisplay(layout.getElementAttribute(element, 'x-display') == 'true');
   shape.setDesc(layout.getElementAttribute(element, 'x-desc'));
@@ -158,6 +163,7 @@ thin.core.ShapeStructure.createLineShapeFromElement = function(element, layout, 
 
 
 /**
+ * @deprecated
  * @param {Element} groupElement
  * @param {thin.core.Layout} layout
  * @return {thin.core.ListShape}
@@ -216,6 +222,7 @@ thin.core.ShapeStructure.createListShapeFromElement = function(groupElement, lay
 
 
 /**
+ * @deprecated
  * @param {Element} element
  * @param {thin.core.Layout} layout
  * @param {thin.core.ShapeIdManager=} opt_shapeIdManager
@@ -251,6 +258,7 @@ thin.core.ShapeStructure.createPageNumberShapeFromElement = function(element, la
 
 
 /**
+ * @deprecated
  * @param {Element} element
  * @param {thin.core.Layout} layout
  * @param {thin.core.ShapeIdManager=} opt_shapeIdManager
@@ -259,10 +267,10 @@ thin.core.ShapeStructure.createPageNumberShapeFromElement = function(element, la
 thin.core.ShapeStructure.createRectShapeFromElement = function(element, layout, opt_shapeIdManager) {
   var shape = new thin.core.RectShape(element, layout,
                     new goog.graphics.Stroke(
-                       Number(layout.getElementAttribute(element, 'stroke-width')), 
+                       Number(layout.getElementAttribute(element, 'stroke-width')),
                        layout.getElementAttribute(element, 'stroke')),
                     new goog.graphics.SolidFill(layout.getElementAttribute(element, 'fill')));
-  
+
   shape.setShapeId(layout.getElementAttribute(element, 'x-id'), opt_shapeIdManager);
   shape.setDisplay(layout.getElementAttribute(element, 'x-display') == 'true');
   shape.setDesc(layout.getElementAttribute(element, 'x-desc'));
@@ -274,6 +282,7 @@ thin.core.ShapeStructure.createRectShapeFromElement = function(element, layout, 
 
 
 /**
+ * @deprecated
  * @param {Element} element
  * @param {thin.core.Layout} layout
  * @param {thin.core.ShapeIdManager=} opt_shapeIdManager
@@ -348,6 +357,7 @@ thin.core.ShapeStructure.createTblockShapeFromElement = function(element, layout
 
 
 /**
+ * @deprecated
  * @param {Element} element
  * @param {thin.core.Layout} layout
  * @param {thin.core.ShapeIdManager=} opt_shapeIdManager

--- a/src/app/core/shapestructure.js
+++ b/src/app/core/shapestructure.js
@@ -114,7 +114,7 @@ thin.core.ShapeStructure.createImageblockShapeFromElement = function(element, la
  */
 thin.core.ShapeStructure.createImageFileFromElement = function(element) {
   var entry = thin.File.createDummyEntry('DummyImageFile');
-  var coreFile = new thin.File(entry, '', element.href.baseVal);
+  var coreFile = new thin.File(entry, '', element['href']['baseVal']);
 
   return new thin.core.ImageFile(coreFile);
 };

--- a/src/app/core/tblockshape.js
+++ b/src/app/core/tblockshape.js
@@ -1797,7 +1797,7 @@ thin.core.TblockShape.prototype.toHash = function() {
   goog.object.extend(hash, {
     'reference-id': this.getRefId(),
     'value': this.getDefaultValueOfLink(),
-    'mulitple-line': this.isMultiMode(),
+    'multiple-line': this.isMultiMode(),
     'format': format
   });
 
@@ -1814,6 +1814,12 @@ thin.core.TblockShape.prototype.toHash = function() {
  * @param {Object} attrs
  */
 thin.core.TblockShape.prototype.update = function(attrs) {
+  if (goog.object.containsKey(attrs, 'style')) {
+    var isMultiple = goog.object.get(attrs,
+      'multiple-line', thin.core.TblockShape.DEFAULT_MULTIPLE);
+    this.setMultiMode(isMultiple);
+  }
+
   goog.base(this, 'update', attrs);
 
   goog.object.forEach(attrs, function(value, attr) {
@@ -1848,9 +1854,6 @@ thin.core.TblockShape.prototype.update = function(attrs) {
         break;
       case 'value':
         this.setDefaultValueOfLink(value);
-        break;
-      case 'mulitple-line':
-        this.setMultiMode(value);
         break;
       case 'overflow':
         this.setOverflowType(value);

--- a/src/app/core/tblockshape.js
+++ b/src/app/core/tblockshape.js
@@ -1782,8 +1782,8 @@ thin.core.TblockShape.prototype.getType = function() {
 /**
  * @return {Object}
  */
-thin.core.TblockShape.prototype.toHash = function() {
-  var hash = goog.base(this, 'toHash');
+thin.core.TblockShape.prototype.asJSON = function() {
+  var object = goog.base(this, 'asJSON');
 
   var format = {
     'base': this.getBaseFormat(),
@@ -1791,22 +1791,22 @@ thin.core.TblockShape.prototype.toHash = function() {
   };
 
   if (this.formatStyle_) {
-    goog.object.extend(format, this.formatStyle_.toHash());
+    goog.object.extend(format, this.formatStyle_.asJSON());
   }
 
-  goog.object.extend(hash, {
+  goog.object.extend(object, {
     'reference-id': this.getRefId(),
     'value': this.getDefaultValueOfLink(),
     'multiple-line': this.isMultiMode(),
     'format': format
   });
 
-  goog.object.extend(hash['style'], {
+  goog.object.extend(object['style'], {
     'overflow': this.getOverflowType(),
     'word-wrap': this.getTextWordWrap()
   });
 
-  return hash;
+  return object;
 };
 
 

--- a/src/app/core/textshape.js
+++ b/src/app/core/textshape.js
@@ -132,50 +132,6 @@ thin.core.TextShape.prototype.updateToolbarUI = function() {
 
 
 /**
- * @param {Element} element
- * @param {thin.core.Layout} layout
- * @param {thin.core.ShapeIdManager=} opt_shapeIdManager
- * @return {thin.core.TextShape}
- */
-thin.core.TextShape.createFromElement = function(element, layout, opt_shapeIdManager) {
-
-  var deco = layout.getElementAttribute(element, 'text-decoration');
-  var lineHeightRatio = layout.getElementAttribute(element, 'x-line-height-ratio');
-  var kerning = layout.getElementAttribute(element, 'kerning');
-  var shape = new thin.core.TextShape(element, layout);
-
-  shape.setShapeId(layout.getElementAttribute(element, 'x-id'), opt_shapeIdManager);
-  shape.setDisplay(layout.getElementAttribute(element, 'x-display') == 'true');
-  shape.setDesc(layout.getElementAttribute(element, 'x-desc'));
-  shape.setFill(new goog.graphics.SolidFill(layout.getElementAttribute(element, 'fill')));
-  shape.createTextContentFromElement(element.childNodes);
-  shape.setFontItalic(layout.getElementAttribute(element, 'font-style') == 'italic');
-  shape.setFontFamily(layout.getElementAttribute(element, 'font-family'));
-  var fontSize = Number(layout.getElementAttribute(element, 'font-size'));
-  shape.setFontSize(fontSize);
-  shape.setFontUnderline(/underline/.test(deco));
-  shape.setFontLinethrough(/line-through/.test(deco));
-  shape.setFontBold(layout.getElementAttribute(element, 'font-weight') == 'bold');
-  shape.setTextAnchor(layout.getElementAttribute(element, 'text-anchor'));
-
-  if (element.hasAttribute('x-valign')) {
-    shape.setVerticalAlign(layout.getElementAttribute(element, 'x-valign'));
-  }
-  if (thin.isExactlyEqual(kerning,
-        thin.core.TextStyle.DEFAULT_ELEMENT_KERNING)) {
-    kerning = thin.core.TextStyle.DEFAULT_KERNING;
-  }
-  shape.setKerning(/** @type {string} */ (kerning));
-  if (!goog.isNull(lineHeightRatio)) {
-    shape.setTextLineHeightRatio(lineHeightRatio);
-  }
-
-  shape.initIdentifier();
-  return shape;
-};
-
-
-/**
  * @param {Element=} opt_element
  * @return {thin.core.Box}
  * @private
@@ -1110,4 +1066,43 @@ thin.core.TextShape.prototype.disposeInternal = function() {
     textline.dispose();
   });
   delete this.textLineContainer_;
+};
+
+
+/**
+ * @return {string}
+ */
+thin.core.TextShape.prototype.getType = function() {
+  return 'text';
+};
+
+
+/**
+ * @return {Object}
+ */
+thin.core.TextShape.prototype.toHash = function() {
+  var hash = goog.base(this, 'toHash');
+
+  goog.object.set(hash, 'texts', this.getTextContent().split("\n"));
+
+  return hash;
+};
+
+
+/**
+ * @param {Object} attrs
+ */
+thin.core.TextShape.prototype.update = function(attrs) {
+  goog.base(this, 'update', attrs);
+
+  goog.object.forEach(attrs, function(value, attr) {
+    switch (attr) {
+      case 'texts':
+        this.setTextContent(value.join("\n"));
+        break;
+      default:
+        // Do Nothing
+        break;
+      }
+  }, this);
 };

--- a/src/app/core/textshape.js
+++ b/src/app/core/textshape.js
@@ -1098,7 +1098,9 @@ thin.core.TextShape.prototype.update = function(attrs) {
   goog.object.forEach(attrs, function(value, attr) {
     switch (attr) {
       case 'texts':
-        this.setTextContent(value.join("\n"));
+        this.createTextContent(value.join("\n"));
+        this.updateDecoration();
+        this.updatePosition();
         break;
       default:
         // Do Nothing

--- a/src/app/core/textshape.js
+++ b/src/app/core/textshape.js
@@ -1080,12 +1080,12 @@ thin.core.TextShape.prototype.getType = function() {
 /**
  * @return {Object}
  */
-thin.core.TextShape.prototype.toHash = function() {
-  var hash = goog.base(this, 'toHash');
+thin.core.TextShape.prototype.asJSON = function() {
+  var object = goog.base(this, 'asJSON');
 
-  goog.object.set(hash, 'texts', this.getTextContent().split("\n"));
+  goog.object.set(object, 'texts', this.getTextContent().split("\n"));
 
-  return hash;
+  return object;
 };
 
 
@@ -1095,16 +1095,9 @@ thin.core.TextShape.prototype.toHash = function() {
 thin.core.TextShape.prototype.update = function(attrs) {
   goog.base(this, 'update', attrs);
 
-  goog.object.forEach(attrs, function(value, attr) {
-    switch (attr) {
-      case 'texts':
-        this.createTextContent(value.join("\n"));
-        this.updateDecoration();
-        this.updatePosition();
-        break;
-      default:
-        // Do Nothing
-        break;
-      }
-  }, this);
+  if (goog.object.containsKey(attrs, 'texts')) {
+    this.createTextContent(attrs['texts'].join("\n"));
+    this.updateDecoration();
+    this.updatePosition();
+  }
 };

--- a/src/app/core/workspace/backup.js
+++ b/src/app/core/workspace/backup.js
@@ -29,8 +29,7 @@ goog.require('thin.core.LayoutStructure');
  */
 thin.core.Workspace.Backup = function(workspace) {
   var format = thin.layout.Format.parse(workspace.format.toJSON());
-  var svg = thin.core.LayoutStructure.createBackup(workspace.getLayout());
-  format.setSvg(svg);
+  format.setSvg(workspace.getLayout().toHash());
 
   /**
    * @type {thin.layout.Format}

--- a/src/app/core/workspace/backup.js
+++ b/src/app/core/workspace/backup.js
@@ -29,7 +29,7 @@ goog.require('thin.core.LayoutStructure');
  */
 thin.core.Workspace.Backup = function(workspace) {
   var format = thin.layout.Format.parse(workspace.format.toJSON());
-  format.setSvg(workspace.getLayout().toHash());
+  format.setItems(workspace.getLayout().asJSON());
 
   /**
    * @type {thin.layout.Format}

--- a/src/app/core/workspace/workspace.js
+++ b/src/app/core/workspace/workspace.js
@@ -356,7 +356,7 @@ thin.core.Workspace.prototype.draw = function() {
     var layout = this.getLayout();
     var format = layout.getFormat();
 
-    thin.Compatibility.applyIf(format.getVersion(), '<', '1.0.0', function() {
+    thin.Compatibility.applyIf(format.getVersion(), '<', '0.9.0', function() {
       thin.core.LayoutStructure.convertToNewLayoutSchema(layout);
     });
 

--- a/src/app/core/workspace/workspace.js
+++ b/src/app/core/workspace/workspace.js
@@ -360,7 +360,7 @@ thin.core.Workspace.prototype.draw = function() {
       thin.core.LayoutStructure.convertToNewLayoutSchema(layout);
     });
 
-    layout.drawShapes(format.getSvg());
+    layout.drawShapes(format.getItems());
     this.setup();
 
     return true;
@@ -633,8 +633,9 @@ thin.core.Workspace.prototype.setFormat = function(format) {
 thin.core.Workspace.prototype.getSaveFormat_ = function() {
   var layout = this.layout_;
   var format = this.format;
-  format.setSvg(layout.toHash());
+  format.setItems(layout.asJSON());
   format.setLayoutGuides(layout.getHelpers().getLayoutGuideHelper().getGuides());
+
   return format.toJSON();
 };
 

--- a/src/app/layout/format.js
+++ b/src/app/layout/format.js
@@ -34,7 +34,7 @@ thin.layout.Format = function(opt_format) {
   var currentVersion = thin.getVersion();
 
   if (goog.isDefAndNotNull(opt_format) && goog.isObject(opt_format)) {
-    this.setSvg(opt_format['items']);
+    this.setItems(opt_format['items']);
     this.page = this.setPage(opt_format['report']);
     this.page.setTitle(opt_format['title']);
 
@@ -76,10 +76,10 @@ thin.layout.Format.prototype.isOverWritableVersion_ = false;
 
 
 /**
- * @type {string}
+ * @type {Object}
  * @private
  */
-thin.layout.Format.prototype.svg_;
+thin.layout.Format.prototype.items_;
 
 
 /**
@@ -94,12 +94,12 @@ thin.layout.Format.prototype.state_;
  * @return {thin.layout.Format}
  */
 thin.layout.Format.parse = function(content) {
-  var hash = JSON.parse(content);
-  var version = hash['version'];
+  var object = JSON.parse(content);
+  var version = object['version'];
 
   thin.Compatibility.applyIf(version, '<', '0.9.0', function() {
-    var state = goog.object.clone(hash['state']);
-    var config = goog.object.clone(hash['config']);
+    var state = goog.object.clone(object['state']);
+    var config = goog.object.clone(object['config']);
     var page = goog.object.clone(config['page']);
 
     var margin = [];
@@ -121,18 +121,18 @@ thin.layout.Format.parse = function(content) {
       });
     }
 
-    goog.object.set(hash, 'title', config['title']);
-    goog.object.set(hash, 'report', report);
-    goog.object.set(hash, 'items', hash['svg']);
-    goog.object.set(hash, 'state', {
+    goog.object.set(object, 'title', config['title']);
+    goog.object.set(object, 'report', report);
+    goog.object.set(object, 'items', object['svg']);
+    goog.object.set(object, 'state', {
       'layout-guides': state['layout-guide']
     });
 
-    goog.object.remove(hash, 'config');
-    goog.object.remove(hash, 'svg');
+    goog.object.remove(object, 'config');
+    goog.object.remove(object, 'svg');
   });
 
-  return new thin.layout.Format(hash);
+  return new thin.layout.Format(object);
 };
 
 
@@ -144,24 +144,24 @@ thin.layout.Format.prototype.toJSON = function() {
     this.version_ = thin.getVersion();
   }
 
-  var hash = {
+  var object = {
     "version": this.version_,
-    "items": this.svg_,
+    "items": this.items_,
     "state": {
       "layout-guides": this.getLayoutGuides()
     }
   };
-  goog.object.extend(hash, this.page.toHash());
+  goog.object.extend(object, this.page.asJSON());
 
-  return JSON.stringify(hash, null, '  ');
+  return JSON.stringify(object, null, '  ');
 };
 
 
 /**
- * @return {string}
+ * @return {object}
  */
-thin.layout.Format.prototype.getSvg = function() {
-  return this.svg_;
+thin.layout.Format.prototype.getItems = function() {
+  return this.items_;
 };
 
 
@@ -198,10 +198,10 @@ thin.layout.Format.prototype.setLayoutGuides = function(guides) {
 
 
 /**
- * @param {Object} svg
+ * @param {Object} items
  */
-thin.layout.Format.prototype.setSvg = function(svg) {
-  this.svg_ = svg;
+thin.layout.Format.prototype.setItems = function(items) {
+  this.items_ = items;
 };
 
 

--- a/src/app/layout/formatpage.js
+++ b/src/app/layout/formatpage.js
@@ -104,6 +104,7 @@ thin.layout.FormatPage.DirectionType = {
 thin.layout.FormatPage.DEFAULT_SETTINGS = {
   'paper-type': thin.layout.FormatPage.PaperType['A4'],
   'orientation': thin.layout.FormatPage.DirectionType.PR,
+  // [top, right, bottom, left]
   'margin': [20, 20, 20, 20]
 };
 
@@ -252,7 +253,7 @@ thin.layout.FormatPage.prototype.setMargin = function(top, right, bottom, left) 
 /**
  * @return {Object}
  */
-thin.layout.FormatPage.prototype.toHash = function() {
+thin.layout.FormatPage.prototype.asJSON = function() {
   var report = {
     "paper-type": this.getPaperType(),
     "orientation": this.getOrientation(),

--- a/src/app/layout/formatpage.js
+++ b/src/app/layout/formatpage.js
@@ -31,8 +31,8 @@ goog.require('goog.Disposable');
  * @extends {goog.Disposable}
  */
 thin.layout.FormatPage = function(config) {
-  goog.Disposable.call(this);
-  
+  goog.base(this);
+
   var page = goog.object.clone(thin.layout.FormatPage.DEFAULT_SETTINGS);
   goog.object.extend(page, Object(goog.object.get(config, 'page')));
   
@@ -40,17 +40,9 @@ thin.layout.FormatPage = function(config) {
                 page['orientation'],
                 page['width'],
                 page['height']);
-  
-  this.setMargin(page['margin-top'],
-                 page['margin-right'],
-                 page['margin-bottom'],
-                 page['margin-left']);
-  
-  /**
-   * @type {string}
-   * @private
-   */
-  this.title_ = config['title'];
+
+  var margin = page['margin'];
+  this.setMargin(margin[0], margin[1], margin[2], margin[3]);
 };
 goog.inherits(thin.layout.FormatPage, goog.Disposable);
 
@@ -113,11 +105,15 @@ thin.layout.FormatPage.DirectionType = {
 thin.layout.FormatPage.DEFAULT_SETTINGS = {
   'paper-type': thin.layout.FormatPage.PaperType['A4'],
   'orientation': thin.layout.FormatPage.DirectionType.PR,
-  'margin-top': 20,
-  'margin-bottom': 20,
-  'margin-left': 20,
-  'margin-right': 20
+  'margin': [20, 20, 20, 20]
 };
+
+
+/**
+ * @type {string}
+ * @private
+ */
+thin.layout.FormatPage.prototype.title_;
 
 
 /**
@@ -258,28 +254,28 @@ thin.layout.FormatPage.prototype.setMargin = function(top, right, bottom, left) 
  * @return {Object}
  */
 thin.layout.FormatPage.prototype.toHash = function() {
-  var hash = {
-    "title": this.title_,
-    "option": {}
-  };
-  
-  var page = {
+  var report = {
     "paper-type": this.getPaperType(),
     "orientation": this.getOrientation(),
-    "margin-top": this.marginTop_,
-    "margin-bottom": this.marginBottom_,
-    "margin-left": this.marginLeft_,
-    "margin-right": this.marginRight_
-  }
+    "margin": [
+      this.marginTop_,
+      this.marginRight_,
+      this.marginBottom_,
+      this.marginLeft_
+    ]
+  };
 
   if (this.isUserType()) {
-    page["width"] = this.getWidth();
-    page["height"] = this.getHeight();
+    goog.object.extend(report, {
+      "width": this.getWidth(),
+      "height": this.getHeight()
+    });
   }
-  
-  hash["page"] = page;
 
-  return hash;
+  return {
+    "title": this.title_,
+    "report": report
+  };
 };
 
 

--- a/src/app/layout/formatpage.js
+++ b/src/app/layout/formatpage.js
@@ -34,8 +34,7 @@ thin.layout.FormatPage = function(config) {
   goog.base(this);
 
   var page = goog.object.clone(thin.layout.FormatPage.DEFAULT_SETTINGS);
-  goog.object.extend(page, Object(goog.object.get(config, 'page')));
-  
+  goog.object.extend(page, config);
   this.setPaper(page['paper-type'],
                 page['orientation'],
                 page['width'],
@@ -237,16 +236,16 @@ thin.layout.FormatPage.prototype.getMarginRight = function() {
 
 
 /**
- * @param {number} top
- * @param {number} right
- * @param {number} bottom
- * @param {number} left
+ * @param {number|string} top
+ * @param {number|string} right
+ * @param {number|string} bottom
+ * @param {number|string} left
  */
 thin.layout.FormatPage.prototype.setMargin = function(top, right, bottom, left) {
-  this.marginTop_ = top;
-  this.marginRight_ = right;
-  this.marginBottom_ = bottom;
-  this.marginLeft_ = left;
+  this.marginTop_ = Number(top);
+  this.marginRight_ = Number(right);
+  this.marginBottom_ = Number(bottom);
+  this.marginLeft_ = Number(left);
 };
 
 
@@ -337,18 +336,18 @@ thin.layout.FormatPage.prototype.setOrientation = function(orientation) {
 
 
 /**
- * @param {number} width
+ * @param {number|string} width
  */
 thin.layout.FormatPage.prototype.setWidth = function(width) {
-  this.width_ = width;
+  this.width_ = Number(width);
 };
 
 
 /**
- * @param {number} height
+ * @param {number|string} height
  */
 thin.layout.FormatPage.prototype.setHeight = function(height) {
-  this.height_ = height;
+  this.height_ = Number(height);
 };
 
 
@@ -399,7 +398,7 @@ thin.layout.FormatPage.prototype.isUserType = function() {
 /** @inheritDoc */
 thin.layout.FormatPage.prototype.disposeInternal = function() {
   thin.layout.FormatPage.superClass_.disposeInternal.call(this);
-  
+
   delete this.paperType_;
   delete this.orientation_;
 };

--- a/src/app/layout/layout.js
+++ b/src/app/layout/layout.js
@@ -35,8 +35,8 @@ thin.layout.CompatibilityRule = {
  * @enum {number}
  */
 thin.layout.CompatibilityState = {
-  COMPLETE: 0x01, 
-  WARNING: 0x02, 
+  COMPLETE: 0x01,
+  WARNING: 0x02,
   ERROR: 0x03
 };
 

--- a/src/app/version.js
+++ b/src/app/version.js
@@ -21,19 +21,19 @@ goog.require('goog.string');
 /**
  * @type {number}
  */
-thin.Version.MAJOR = 1;
+thin.Version.MAJOR = 0;
 
 
 /**
  * @type {number}
  */
-thin.Version.MINOR = 0;
+thin.Version.MINOR = 8;
 
 
 /**
  * @type {number}
  */
-thin.Version.TINY = 0;
+thin.Version.TINY = 2;
 
 
 /**
@@ -72,7 +72,7 @@ thin.getVersion = function(opt_ignorePre) {
  * @return {string}
  */
 thin.getNextMajorVersion = function() {
-  return String((thin.Version.MAJOR + (thin.Version.MINOR * 0.1)) + 0.1) + '.0';
+  return '1.0.0';
 };
 
 

--- a/src/app/version.js
+++ b/src/app/version.js
@@ -21,19 +21,19 @@ goog.require('goog.string');
 /**
  * @type {number}
  */
-thin.Version.MAJOR = 0;
+thin.Version.MAJOR = 1;
 
 
 /**
  * @type {number}
  */
-thin.Version.MINOR = 8;
+thin.Version.MINOR = 0;
 
 
 /**
  * @type {number}
  */
-thin.Version.TINY = 2;
+thin.Version.TINY = 0;
 
 
 /**
@@ -72,7 +72,7 @@ thin.getVersion = function(opt_ignorePre) {
  * @return {string}
  */
 thin.getNextMajorVersion = function() {
-  return '1.0.0';
+  return String((thin.Version.MAJOR + (thin.Version.MINOR * 0.1)) + 0.1) + '.0';
 };
 
 


### PR DESCRIPTION
-  全ての情報を JSON でレイアウトファイルに記録する
  - [x] List 以外の図形の JSON スキーマを統一された理解しやすい構造へ改善
  - [x] List の JSON スキーマを各セクション毎に各図形スキーマを含む構造へ改善
- SVG の構造や属性の内包、SVG との依存を完全に排除する
  - [x] 下位互換性を保つため古いスキーマの読み込み時は新しいスキーマに変換した後、読み込む
    - 旧スキーマ → 旧スキーマから新スキーマに変換（単独クラス） → JSONから生成 → 描画完了
    - 新スキーマ → JSONから生成 → 描画完了
 - [x] スキーマフォーマットを pretty 固定

Refer to: https://github.com/thinreports/thinreports/issues/4