### PR TITLE
Line-height calculation result will be different values ​​depending on the environment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## master
+
+### Bugfixes
+
+ * Fixed: the line-height property returns different calculation results depending on environment (#71)
+
 ## 0.10.0
 
 ### Released as an Electron based desktop application

--- a/app/editor/core/layout.js
+++ b/app/editor/core/layout.js
@@ -137,6 +137,7 @@ thin.core.Layout.prototype.drawShape = function(item, opt_sectionShape) {
 
     case 'text-block':
       shape = this.createTblockShape();
+      shape.setRawFormat(item);
       break;
 
     case 'page-number':
@@ -145,6 +146,7 @@ thin.core.Layout.prototype.drawShape = function(item, opt_sectionShape) {
 
     case 'text':
       shape = this.createTextShape();
+      shape.setRawFormat(item);
       break;
 
     case 'image':


### PR DESCRIPTION
## Steps to reproduce

1. Create template as `sample.tlf` with `font-family=Helvetica, font-size=18, line-height-ratio=1.5` on the dot-by-dot display
    - The `line-height` in `sample.tlf` will be `31.5`
2. Update template without changing the `line-height-ratio` and `font-size` and `font-family` on the Retina display
    - The `line-height` in `sample.tlf` won't be `31.5`

## How to fix this problem

When editing a template, use calculated `line-height` ​​as much as possible. When creating a new template, calculate the value.

- In the case of new creation:
  - The behavior is not changed
- In the case of editing:
  - Always use the raw `line-height` value if `font-size` and `font-family` and `line-height-ratio` all match the raw valueu