### PR TITLE
Build and release on CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,64 @@
+name: Build and release
+
+on:
+  push:
+    branches:
+      - build/**
+    tags:
+      - '*'
+
+jobs:
+  build:
+    runs-on: ${{ matrix.os }}
+
+    strategy:
+      matrix:
+        os: [macos-latest, ubuntu-latest, windows-latest]
+        include:
+          - os: macos-latest
+            build: macos
+          - os: ubuntu-latest
+            build: linux
+          - os: windows-latest
+            build: windows
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Setup Java JDK
+        uses: actions/setup-java@v1.3.0
+        with:
+          java-version: 7
+
+      - name: Setup Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: 2.7
+
+      - name: Install Node.js
+        uses: actions/setup-node@v1
+        with:
+          node-version: 13
+      - name: Install npm packages
+        run: npm install
+
+      - name: Compile scripts
+        run: npm run compile:prod
+
+      - name: Build ${{ matrix.build }}
+        run: npm run build:${{ matrix.build }}
+
+      - name: Upload to artifact if not tagged
+        uses: actions/upload-artifact@v2
+        if: "!startsWith(github.ref, 'refs/tags')"
+        with:
+          name: ${{ matrix.build }}
+          path: builds/*.zip
+
+      - name: Release if tagged
+        uses: softprops/action-gh-release@v1
+        if: startsWith(github.ref, 'refs/tags/')
+        with:
+          files: builds/*.zip
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/package.json
+++ b/package.json
@@ -11,8 +11,12 @@
     "compile:javascript": "node tasks/compile.javascript.js",
     "compile:css": "node tasks/compile.css.js",
     "compile:template": "node tasks/compile.template.js",
+    "compile:prod": "cross-env NODE_ENV=production npm run compile",
     "build": "node tasks/build.js",
-    "release": "cross-env NODE_ENV=production npm run compile && npm run build",
+    "build:macos": "node tasks/build.js darwin",
+    "build:windows": "node tasks/build.js win32",
+    "build:linux": "node tasks/build.js linux",
+    "release": "npm run compile:prod && npm run build",
     "watch": "node tasks/watch.js",
     "postinstall": "cd app && npm install"
   },

--- a/tasks/build.js
+++ b/tasks/build.js
@@ -6,6 +6,8 @@ const archiver = require('archiver')
 const path = require('path')
 const fs = require('fs')
 
+const targetPlatforms = process.argv[2] ? [process.argv[2]] : ['darwin', 'linux', 'win32']
+
 const config = {
   packager: {
     arch: 'x64',
@@ -15,7 +17,7 @@ const config = {
     ignore: 'editor/',
     out: path.join(where.root, 'builds'),
     overwrite: true,
-    platform: ['darwin', 'linux', 'win32']
+    platform: targetPlatforms
   },
   packageName: {
     'Thinreports Editor-darwin-x64': 'ThinreportsEditor-mac',


### PR DESCRIPTION
Depends on #76

## Overview

This PR adds a job for building and releasing a package for each platform.

## Job

when tagged:

1. build package
2. create release for pushed tag
3. upload the package to the release

when pushed to `build/*` branch

1. build package
2. upload the package to artifact (This PR)

## Review

See https://github.com/thinreports/thinreports-editor/actions/runs/135218919


