### PR TITLE
Fix logo in splash is not displayed

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,1 @@
+node_modules

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,8 @@
+FROM ubuntu:18.04
+
+RUN apt-get update && apt-get install -y curl gnupg2 nodejs npm openjdk-11-jdk-headless python
+
+RUN mkdir /src
+WORKDIR /src
+
+CMD ["bash", "-c", "npm i && npm run compile"]

--- a/README.md
+++ b/README.md
@@ -91,6 +91,22 @@ Run compilation and building on production:
 $ npm run release
 ```
 
+### Compiling using Docker Container
+
+Or if you can use docker, you can compile script and css:
+
+```
+$ docker build -t thinreports-editor:latest .
+$ docker run --rum -v $PWD:/src thinreports-editor:latest
+Compiling JavaScript with SIMPLE_OPTIMIZATIONS...
+```
+
+And, launch electron on development:
+
+```
+$ npm start
+```
+
 ## License
 
 Thinreports Editor is licensed under the [GPLv3](https://github.com/thinreports/thinreports-editor/blob/master/GPLv3).

--- a/app/assets/splash.css
+++ b/app/assets/splash.css
@@ -1,16 +1,16 @@
 /**
  * Copyright (C) 2011 Matsukei Co.,Ltd.
- * 
+ *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
@@ -23,7 +23,7 @@ html.splash {
   background-repeat: no-repeat;
   background-position: center center;
   background-size: 300px;
-  -webkit-animation-duration: 1.5s;
+  -webkit-animation-duration: .2s;
   -webkit-animation-name: splash-fade-in;
 }
 


### PR DESCRIPTION
Depends on #76 

## Abstract

This PR fixes that the thinreports logo in starup splash is not displayed with electron v9.

## Fixed behavior

![Fw9r6PwJlI](https://user-images.githubusercontent.com/739339/84678558-1e200d80-af6b-11ea-940e-7f02cf64ce92.gif)

## Other Changes

This PR adds Dockerfile to compile script and css for developing.