### PR TITLE
Release 0.11.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,16 @@
 ## master
 
+## 0.11.0
+
 ### Bugfixes
 
  * Fixed: the line-height property returns different calculation results depending on environment (#71)
  * Fixed: the line-height of a text-block is not recalculated when changing font-size (#72)
+ * Fixed: does not launch on Ubuntu 20.04 (#75)
+
+### Internal Changes
+
+ * Update to Electron v9 (#76)
 
 ## 0.10.0
 

--- a/README.md
+++ b/README.md
@@ -26,9 +26,9 @@ Please [contribute to translate](https://github.com/thinreports/thinreports-edit
 
 We tested the following platform:
 
- * macOS 10.12
+ * macOS 10.15
  * Windows 10
- * Ubuntu 16.04
+ * Ubuntu 18.04, 20.04
 
 ## Supported Layout versions
 

--- a/README.md
+++ b/README.md
@@ -107,6 +107,37 @@ And, launch electron on development:
 $ npm start
 ```
 
+## Releasing Editor
+
+This steps are for releasing a new version of Editor.
+
+### 1. Update to the new version
+
+The following two files need to be updated.
+
+- app/editor/version.js
+- app/package.json
+
+### 2. Update documents
+
+- CHANGELOG.md (required)
+- README.md (if needed)
+
+### 3. Push them to `build/release-x.x.x` branch and test the built packages for each platform
+
+Pushing to `build/*` branch runs a job to build the package. Make sure that the built packages for each platform work properly. You can download the packages from the artifact of the build. For more information, see [Build workflow](.github/workflows/build.yml).
+
+### 4. Create pullrequest
+
+If there is no problem, create a pullrequest.
+
+### 5. Merge pullrequest and push tag
+
+Pushing a tag runs a job to build and release package. Check the followings:
+
+- Correct version and content of the release
+- All package files are attached to the release
+
 ## License
 
 Thinreports Editor is licensed under the [GPLv3](https://github.com/thinreports/thinreports-editor/blob/master/GPLv3).

--- a/app/editor/version.js
+++ b/app/editor/version.js
@@ -27,7 +27,7 @@ thin.Version.MAJOR = 0;
 /**
  * @type {number}
  */
-thin.Version.MINOR = 10;
+thin.Version.MINOR = 11;
 
 
 /**

--- a/app/package.json
+++ b/app/package.json
@@ -1,7 +1,7 @@
 {
   "name": "thinreports-editor",
   "productName": "Thinreports Editor",
-  "version": "0.10.0",
+  "version": "0.11.0",
   "license": "GPL-3.0",
   "description": "Designer for Thinreports",
   "main": "main.js"


### PR DESCRIPTION
## Abstract

Both generator and editor have some unreleased changes. I propose to release v0.11.0.

## Release Steps

I wrote the release steps. This Pullrequest also follows the steps.

## Testing the built packages for each platform

You can download the built packages:
https://github.com/thinreports/thinreports-editor/actions/runs/138679094

- [x] macos
- [x] linux
- [x] windows

@maeda-m Could you test the package for windows?

## Other tasks

- [x] Create pullrequest for releasing generator v0.11.0 https://github.com/thinreports/thinreports-generator/pull/105