### PR TITLE
Release v0.12.0

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,7 +26,7 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: Setup Java JDK
-        uses: actions/setup-java@v1.3.0
+        uses: actions/setup-java@v1.4.3
         with:
           java-version: 7
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
-## master
+## master (Unreleased)
+
+## 0.12.0
+
+### Enhancements
 
  * Adds CTRL+Mouse wheel zoom #85 [@rhiroshi]
 

--- a/app/editor/version.js
+++ b/app/editor/version.js
@@ -27,7 +27,7 @@ thin.Version.MAJOR = 0;
 /**
  * @type {number}
  */
-thin.Version.MINOR = 11;
+thin.Version.MINOR = 12;
 
 
 /**

--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -1,5 +1,5 @@
 {
   "name": "thinreports-editor",
-  "version": "0.11.0",
+  "version": "0.12.0",
   "lockfileVersion": 1
 }

--- a/app/package.json
+++ b/app/package.json
@@ -1,7 +1,7 @@
 {
   "name": "thinreports-editor",
   "productName": "Thinreports Editor",
-  "version": "0.11.0",
+  "version": "0.12.0",
   "license": "GPL-3.0",
   "description": "Designer for Thinreports",
   "main": "main.js"


### PR DESCRIPTION
## Abstract

リリースしていない新機能と electron のアップデートなど、重要な内部的な変更もあるため v0.12.0 としてリリースしたいと思います。

## Testing the built packages for each platform

各プラットフォームのビルド済みパッケージはこちらからダウンロードできます:
https://github.com/thinreports/thinreports-editor/actions/runs/483240622

- [x] macos
- [x] linux
- [x] windows

@maeda-m mac と linux はやるので、Windows の動作を軽く見て欲しいです。