### PR TITLE
Enable workflow_dispatch trigger for build workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,6 +6,7 @@ on:
       - build/**
     tags:
       - '*'
+  workflow_dispatch:
 
 jobs:
   build:


### PR DESCRIPTION
build.yml は editor のバイナリを構築し、artifact に保存してくれる workflow ですが、現状これは下記のタイミングで実行されます。

- `build/**` ブランチに push したとき
- タグを push したとき

しかし、例えば https://github.com/thinreports/thinreports-editor/pull/92 のような PR の動作確認でも使用できると便利なので、この workflow を手動かつ任意のブランチに対して実行できるようにします。

こんな感じで Actions タブから実行できるようになります (これは別のリポジトリの例です)。
![image](https://user-images.githubusercontent.com/739339/106243520-e55c4c80-624c-11eb-8502-47742fd1e1ff.png)

詳細は下記を参照
https://docs.github.com/ja/enterprise-server@3.0/actions/managing-workflow-runs/manually-running-a-workflow
