### PR TITLE
ビルドパッケージのファイル名を section-editor と basic-editor に考慮した名称に変更し統一する

### DIFF
--- a/basic-report/app/package-lock.json
+++ b/basic-report/app/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "thinreports-editor",
+  "name": "thinreports-editor-basic",
   "version": "0.12.0",
   "lockfileVersion": 1
 }

--- a/basic-report/app/package.json
+++ b/basic-report/app/package.json
@@ -1,8 +1,7 @@
 {
-  "name": "thinreports-editor",
-  "productName": "Thinreports Editor",
+  "name": "thinreports-editor-basic",
   "version": "0.12.0",
   "license": "GPL-3.0",
-  "description": "Designer for Thinreports",
+  "description": "A report designer for Thinreports to edit basic-format templates",
   "main": "main.js"
 }

--- a/basic-report/package-lock.json
+++ b/basic-report/package-lock.json
@@ -1,6 +1,6 @@
 {
-  "name": "thinreports-editor",
-  "version": "0.0.0",
+  "name": "thinreports-editor-basic",
+  "version": "0.12.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/basic-report/package.json
+++ b/basic-report/package.json
@@ -1,9 +1,8 @@
 {
-  "name": "thinreports-editor",
-  "productName": "Thinreports Editor",
-  "version": "0.0.0",
+  "name": "thinreports-editor-basic",
+  "version": "0.12.0",
   "license": "GPL-3.0",
-  "description": "Designer for Thinreports",
+  "description": "A report designer for Thinreports to edit basic-format templates",
   "author": "Thinreports.org",
   "scripts": {
     "start": "cross-env NODE_ENV=development electron app",

--- a/basic-report/tasks/build.js
+++ b/basic-report/tasks/build.js
@@ -20,9 +20,9 @@ const config = {
     platform: targetPlatforms
   },
   packageName: {
-    'Thinreports Editor-darwin-x64': 'ThinreportsEditor-mac',
-    'Thinreports Editor-linux-x64': 'ThinreportsEditor-linux',
-    'Thinreports Editor-win32-x64': 'ThinreportsEditor-windows'
+    'thinreports-editor-basic-darwin-x64': `ThinreportsEditor-basic-${package.version}-darwin`,
+    'thinreports-editor-basic-linux-x64': `ThinreportsEditor-basic-${package.version}-linux`,
+    'thinreports-editor-basic-win32-x64': `ThinreportsEditor-basic-${package.version}-win32`
   }
 }
 

--- a/section-report/package.json
+++ b/section-report/package.json
@@ -1,6 +1,7 @@
 {
-  "name": "thinreports-editor",
+  "name": "thinreports-editor-section",
   "version": "1.0.0-sectionreport.1",
+  "description": "A report designer for Thinreports to edit section-format templates",
   "private": true,
   "scripts": {
     "build": "vue-cli-service build",

--- a/section-report/vue.config.js
+++ b/section-report/vue.config.js
@@ -1,16 +1,23 @@
+/* eslint no-template-curly-in-string: 0 */
 module.exports = {
   pluginOptions: {
     electronBuilder: {
       builderOptions: {
-        appId: 'com.thinreports.editor',
-        productName: 'Thinreports Editor',
+        appId: 'com.thinreports.${name}',
+        productName: 'ThinreportsEditor-section',
         publish: null,
         mac: {
+          artifactName: '${productName}-${version}-darwin.${ext}',
           category: 'public.app-category.developer-tools',
           darkModeSupport: false
         },
         linux: {
-          category: 'Development'
+          artifactName: '${productName}-${version}-linux.${ext}',
+          category: 'Development',
+          target: 'AppImage'
+        },
+        win: {
+          artifactName: '${productName}-${version}-win32.${ext}'
         },
         dmg: {
           icon: false


### PR DESCRIPTION
## 目的

以下のタスクを解決する（これらのカードはすでにアーカイブ済み）
https://github.com/orgs/thinreports/projects/1#card-65548661
https://github.com/orgs/thinreports/projects/1#card-65548620

## 方針

ファイル名はどうするか。https://github.com/thinreports/thinreports/issues/24 でも検討中だが、ファイル名は基本的に次のような形式にした。

```
ThinreportsEditor-<basic or section>-<version>-<platform>.<ext>
```

### basic editor

```
ThinreportsEditor-basic-<version>-darwin.zip
ThinreportsEditor-basic-<version>-linux.zip
ThinreportsEditor-basic-<version>-win32.zip
```

### section editor

```
ThinreportsEditor-section-<version>-darwin.dmg
ThinreportsEditor-section-<version>-linux.AppImage
ThinreportsEditor-section-<version>-win32.exe
```

## 実装について

現状、basic editor の windows ビルドでエラーが発生しているが、これは今回の変更とは無関係（原因は不明だが、以前から発生していたと思う）。ubuntu では成功し、ファイル名も期待通りなので問題ないはず。

windows でのビルドエラー（以下）は別で対処する。
https://github.com/thinreports/thinreports-editor/runs/3214785385?check_suite_focus=true

## テスト結果

### basic editor

以下、ビルドで linux (ubuntu-latest) のファイル名が下記の通り期待通りなのを確認した
https://github.com/thinreports/thinreports-editor/actions/runs/1087815508
```
ThinreportsEditor-basic-0.12.0-linux.zip
```

### section editor

ubuntu 21.04 で `npm run electron:build` し、ファイル名が下記の通り期待通りなのを確認した
```
ThinreportsEditor-section-1.0.0-sectionreport.1-linux.AppImage
```
